### PR TITLE
Move client tasks off of executor exposed to user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/src/main/java/com/sproutsocial/nsq/Batcher.java
+++ b/src/main/java/com/sproutsocial/nsq/Batcher.java
@@ -29,7 +29,7 @@ class Batcher {
         this.topic = topic;
         this.maxSize = maxSize;
         this.maxDelayMillis = maxDelayMillis;
-        this.executor = publisher.getClient().getSchedExecutor();
+        this.executor = publisher.getBatchExecutor();
         checkNotNull(publisher);
         checkNotNull(topic);
         checkArgument(maxDelayMillis > 5);

--- a/src/main/java/com/sproutsocial/nsq/PubConnection.java
+++ b/src/main/java/com/sproutsocial/nsq/PubConnection.java
@@ -41,7 +41,7 @@ class PubConnection extends Connection {
         super.close();
         if (!publisher.isStopping) {
             //be paranoid about locks, we only care that this happens sometime soon
-            executor.execute(new Runnable() {
+            client.getSchedExecutor().execute(new Runnable() {
                 public void run() {
                     publisher.connectionClosed(PubConnection.this);
                 }

--- a/src/main/java/com/sproutsocial/nsq/Subscriber.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscriber.java
@@ -3,6 +3,7 @@ package com.sproutsocial.nsq;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
+import net.jcip.annotations.GuardedBy;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +95,7 @@ public class Subscriber extends BasePubSub {
         }
     }
 
+    @GuardedBy("this")
     protected Set<HostAndPort> lookupTopic(String topic) {
         Set<HostAndPort> nsqds = new HashSet<HostAndPort>();
         for (HostAndPort lookup : lookups) {


### PR DESCRIPTION
All administrative client things are now on a 2 thread pool not exposed to the user (instead of the one that handles received messages, which I renamed)

Not sure if this is the cause of connection drops, but it can't hurt.

Also moved the executor used for batch publishing to a single thread per publisher, just to be safe.
Added some doc annotations.

@ccstolley @blakesmith @patrickgombert 