### PR TITLE
Fix compression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/src/main/java/com/sproutsocial/nsq/Subscription.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscription.java
@@ -73,7 +73,7 @@ class Subscription extends BasePubSub {
         }
         List<SubConnection> activeCons = new ArrayList<SubConnection>();
         List<SubConnection> inactiveCons = new ArrayList<SubConnection>();
-        long minActiveTime = Util.clock() - subscriber.getLookupIntervalSecs() * 1000 * 30;
+        long minActiveTime = Util.clock() - (subscriber.getLookupIntervalSecs() + 40) * 1000;
         for (SubConnection con : copy(connectionMap.values())) {
             if (con.lastActionFlush < minActiveTime) {
                 inactiveCons.add(con);


### PR DESCRIPTION
zlib compression was failing about 1 connection out of 20 because data after the initial OK was getting sucked into a BufferedInputStream that was lost when the underlying stream was wrapped in the Inflate/Deflate streams.

Now we never buffer anything until the stream is fully set up, which means a handful of readInts go unbuffered.

Unrelated: make the max-in-flight redistribution more aggressive about inactive connections. The other clients don't have a configurable parameter for this, so we don't expose one.