### PR TITLE
Mark errors as errors when publishing fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>0.9.2</version>
+    <version>0.9.3</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -89,7 +89,7 @@ public class Publisher extends BasePubSub {
             con.publish(topic, data);
         }
         catch (Exception e) {
-            logger.warn("publish error with:{} {}", isFailover ? failoverNsqd : nsqd, e);
+            logger.error("publish error with:{} {}", isFailover ? failoverNsqd : nsqd, e);
             publishFailover(topic, data);
         }
     }
@@ -119,7 +119,7 @@ public class Publisher extends BasePubSub {
             con.publish(topic, dataList);
         }
         catch (Exception e) {
-            logger.warn("publish error with:{} {}", isFailover ? failoverNsqd : nsqd, e);
+            logger.error("publish error with:{} {}", isFailover ? failoverNsqd : nsqd, e);
             for (byte[] data : dataList) {
                 publishFailover(topic, data);
             }


### PR DESCRIPTION
Publishing errors are marked as warnings when tossed up to logging, mark them as errors.