### PR TITLE
Fix failover publishing when primary nsqd stays down

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -57,8 +57,8 @@ public class Publisher extends BasePubSub {
             connect(nsqd);
         }
         else if (isFailover && Util.clock() - failoverStart > failoverDurationSecs * 1000) {
-            connect(nsqd);
             isFailover = false;
+            connect(nsqd);
             logger.info("using primary nsqd");
         }
     }
@@ -145,6 +145,7 @@ public class Publisher extends BasePubSub {
         catch (Exception e) {
             Util.closeQuietly(con);
             con = null;
+            isFailover = false;
             throw new NSQException("publish failed", e);
         }
     }


### PR DESCRIPTION
Thanks @cswingler for finding this!

When failoverDurationSecs (5 minutes) expired, if the primary host was still down then the connect call on line 60 would throw an exception before setting isFailover=false which would prevent us from trying the failover host again. 

This makes sure isFailover matches the state we are really in. 

unrelated improvement: When both hosts are down we now set isFailover=false to try both on every publish.