### PR TITLE
[Bugfix] Allow setting the user agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>0.9.3</version>
+    <version>0.9.4</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/src/main/java/com/sproutsocial/nsq/Config.java
+++ b/src/main/java/com/sproutsocial/nsq/Config.java
@@ -18,7 +18,7 @@ public class Config {
     private Boolean deflate;
     private Integer deflateLevel;
     private Integer sampleRate;
-    private String userAgent;
+    private String userAgent = "nsq-j/0.9";
     private Integer msgTimeout;
 
     //region accessors

--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -44,8 +44,6 @@ abstract class Connection extends BasePubSub implements Closeable {
     private static final ThreadFactory readThreadFactory = Util.threadFactory("nsq-read");
     private static final Set<String> nonFatalErrors = Collections.unmodifiableSet(new HashSet<String>(
             Arrays.asList("E_FIN_FAILED", "E_REQ_FAILED", "E_TOUCH_FAILED")));
-    private static String VERSION = "0.9";
-    private static final String USER_AGENT = String.format("nsq-j/%s", VERSION);
 
     private static final Logger logger = LoggerFactory.getLogger(Connection.class);
 
@@ -113,7 +111,6 @@ abstract class Connection extends BasePubSub implements Closeable {
                 config.setHostname(pidHost.substring(pos + 1));
             }
         }
-        config.setUserAgent(USER_AGENT);
         config.setFeatureNegotiation(true);
     }
 


### PR DESCRIPTION
The current connection setup overwrites the user agent set in the configuration with a statically defined string.  This moves the default into the Config class and allows `setUserAgent()` to be used.

In practice, I'd expect this to be set up with

```
subscriber.getConfig().setUserAgent(subscriber.getConfig().getUserAgent() + " MyUserAgent/1.2");
```

which would report the user agent `nsq-j/0.9 MyUserAgent/1.2`.