### PR TITLE
Update log lines in Publisher to remove extra '{}'

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -89,7 +89,7 @@ public class Publisher extends BasePubSub {
             con.publish(topic, data);
         }
         catch (Exception e) {
-            logger.error("publish error with:{} {}", isFailover ? failoverNsqd : nsqd, e);
+            logger.error("publish error with:{}", isFailover ? failoverNsqd : nsqd, e);
             publishFailover(topic, data);
         }
     }
@@ -119,7 +119,7 @@ public class Publisher extends BasePubSub {
             con.publish(topic, dataList);
         }
         catch (Exception e) {
-            logger.error("publish error with:{} {}", isFailover ? failoverNsqd : nsqd, e);
+            logger.error("publish error with:{}", isFailover ? failoverNsqd : nsqd, e);
             for (byte[] data : dataList) {
                 publishFailover(topic, data);
             }


### PR DESCRIPTION
It looks like below in the logs.
```
publish error with:<host:port> {}
com.sproutsocial.nsq.NSQException: ...
...
```
