### PR TITLE
INFRA-5432: Add support for async batch publishing. Allow connect and read timeouts to be configurable.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/src/main/java/com/sproutsocial/nsq/Batcher.java
+++ b/src/main/java/com/sproutsocial/nsq/Batcher.java
@@ -101,8 +101,8 @@ class Batcher {
     }
 
     /**
-     * If you're going to use async publishing, make sure you set aggressive timeouts, to avoid too much
-     * stalls and lock contention.
+     * If you want asynch batching to never block message publishing, make sure you set aggressive socket timeouts.
+     * Otherwise you'll get stalls when there are batches outstanding.
      */
     private void sendBatchAsync() {
         executor.submit(new Runnable() {

--- a/src/main/java/com/sproutsocial/nsq/Batcher.java
+++ b/src/main/java/com/sproutsocial/nsq/Batcher.java
@@ -100,6 +100,10 @@ class Batcher {
         }
     }
 
+    /**
+     * If you're going to use async publishing, make sure you set aggressive timeouts, to avoid too much
+     * stalls and lock contention.
+     */
     private void sendBatchAsync() {
         executor.submit(new Runnable() {
                 public void run() {

--- a/src/main/java/com/sproutsocial/nsq/Client.java
+++ b/src/main/java/com/sproutsocial/nsq/Client.java
@@ -28,6 +28,8 @@ public class Client {
     private ExecutorService handlerExecutor;
     private SSLSocketFactory sslSocketFactory;
     private byte[] authSecret;
+    private int socketReadTimeoutMillis = 30000;
+    private int socketConnectTimeoutMillis = 30000;
 
     private static final Logger logger = LoggerFactory.getLogger(Client.class);
     private static final Client defaultClient = new Client();
@@ -131,6 +133,22 @@ public class Client {
 
     public synchronized void setAuthSecret(String authSecret) {
         this.authSecret = authSecret.getBytes();
+    }
+
+    public synchronized int getSocketReadTimeoutMillis() {
+        return socketReadTimeoutMillis;
+    }
+
+    public synchronized void setSocketReadTimeoutMillis(int socketReadTimeoutMillis) {
+        this.socketReadTimeoutMillis = socketReadTimeoutMillis;
+    }
+
+    public synchronized int getSocketConnectTimeoutMillis() {
+        return socketConnectTimeoutMillis;
+    }
+
+    public synchronized void setSocketConnectTimeoutMillis(int socketConnectTimeoutMillis) {
+        this.socketConnectTimeoutMillis = socketConnectTimeoutMillis;
     }
 
     //--------------------------

--- a/src/main/java/com/sproutsocial/nsq/Config.java
+++ b/src/main/java/com/sproutsocial/nsq/Config.java
@@ -20,8 +20,6 @@ public class Config {
     private Integer sampleRate;
     private String userAgent = "nsq-j/0.9";
     private Integer msgTimeout;
-    private Integer socketReadTimeoutMillis = 30000;
-    private Integer socketConnectTimeoutMillis = 30000;
 
     //region accessors
     public String getClientId() {
@@ -127,22 +125,6 @@ public class Config {
     public void setMsgTimeout(Integer msgTimeout) {
         this.msgTimeout = msgTimeout;
     }
-
-    public Integer getSocketReadTimeoutMillis() {
-        return socketReadTimeoutMillis;
-    }
-
-    public void setSocketReadTimeoutMillis(Integer socketReadTimeoutMillis) {
-        this.socketReadTimeoutMillis = socketReadTimeoutMillis;
-    }
-
-    public Integer getSocketConnectTimeoutMillis() {
-        return socketConnectTimeoutMillis;
-    }
-
-    public void setSocketConnectTimeoutMillis(Integer socketConnectTimeoutMillis) {
-        this.socketConnectTimeoutMillis = socketConnectTimeoutMillis;
-    }
     //endregion
 
     @Override
@@ -161,8 +143,6 @@ public class Config {
                 ", sampleRate=" + sampleRate +
                 ", userAgent='" + userAgent + '\'' +
                 ", msgTimeout=" + msgTimeout +
-                ", socketReadTimeoutMillis=" + socketReadTimeoutMillis +
-                ", socketConnectTimeoutMillis=" + socketConnectTimeoutMillis +
                 '}';
     }
 }

--- a/src/main/java/com/sproutsocial/nsq/Config.java
+++ b/src/main/java/com/sproutsocial/nsq/Config.java
@@ -20,6 +20,8 @@ public class Config {
     private Integer sampleRate;
     private String userAgent = "nsq-j/0.9";
     private Integer msgTimeout;
+    private Integer socketReadTimeoutMillis = 30000;
+    private Integer socketConnectTimeoutMillis = 30000;
 
     //region accessors
     public String getClientId() {
@@ -125,6 +127,22 @@ public class Config {
     public void setMsgTimeout(Integer msgTimeout) {
         this.msgTimeout = msgTimeout;
     }
+
+    public Integer getSocketReadTimeoutMillis() {
+        return socketReadTimeoutMillis;
+    }
+
+    public void setSocketReadTimeoutMillis(Integer socketReadTimeoutMillis) {
+        this.socketReadTimeoutMillis = socketReadTimeoutMillis;
+    }
+
+    public Integer getSocketConnectTimeoutMillis() {
+        return socketConnectTimeoutMillis;
+    }
+
+    public void setSocketConnectTimeoutMillis(Integer socketConnectTimeoutMillis) {
+        this.socketConnectTimeoutMillis = socketConnectTimeoutMillis;
+    }
     //endregion
 
     @Override
@@ -143,6 +161,8 @@ public class Config {
                 ", sampleRate=" + sampleRate +
                 ", userAgent='" + userAgent + '\'' +
                 ", msgTimeout=" + msgTimeout +
+                ", socketReadTimeoutMillis=" + socketReadTimeoutMillis +
+                ", socketConnectTimeoutMillis=" + socketConnectTimeoutMillis +
                 '}';
     }
 }

--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -56,8 +56,8 @@ abstract class Connection extends BasePubSub implements Closeable {
     public synchronized void connect(Config config) throws IOException {
         addClientConfig(config);
         Socket sock = new Socket();
-        sock.setSoTimeout(config.getSocketReadTimeoutMillis());
-        sock.connect(new InetSocketAddress(host.getHost(), host.getPort()), config.getSocketConnectTimeoutMillis());
+        sock.setSoTimeout(client.getSocketReadTimeoutMillis());
+        sock.connect(new InetSocketAddress(host.getHost(), host.getPort()), client.getSocketConnectTimeoutMillis());
         StreamPair streams = setStreams(sock.getInputStream(), sock.getOutputStream(), new StreamPair());
         out.write("  V2".getBytes(Util.US_ASCII));
 

--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -56,8 +56,8 @@ abstract class Connection extends BasePubSub implements Closeable {
     public synchronized void connect(Config config) throws IOException {
         addClientConfig(config);
         Socket sock = new Socket();
-        sock.setSoTimeout(30000);
-        sock.connect(new InetSocketAddress(host.getHost(), host.getPort()), 30000);
+        sock.setSoTimeout(config.getSocketReadTimeoutMillis());
+        sock.connect(new InetSocketAddress(host.getHost(), host.getPort()), config.getSocketConnectTimeoutMillis());
         StreamPair streams = setStreams(sock.getInputStream(), sock.getOutputStream(), new StreamPair());
         out.write("  V2".getBytes(Util.US_ASCII));
 

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -163,11 +163,15 @@ public class Publisher extends BasePubSub {
     }
 
     public synchronized void setBatchConfig(String topic, int maxSizeBytes, int maxDelayMillis) {
+        setBatchConfig(topic, maxSizeBytes, maxDelayMillis, false);
+    }
+
+    public synchronized void setBatchConfig(String topic, int maxSizeBytes, int maxDelayMillis, boolean asyncPublish) {
         Batcher batcher = batchers.get(topic);
         if (batcher != null) {
             batcher.sendBatch();
         }
-        batcher = new Batcher(this, topic, maxSizeBytes, maxDelayMillis);
+        batcher = new Batcher(this, topic, maxSizeBytes, maxDelayMillis, asyncPublish);
         batchers.put(topic, batcher);
     }
 


### PR DESCRIPTION
Two things in this PR:

1. Allow batch publishing to use the executor service to send the batch.
2. Allow connect and read timeouts to be configurable on the `Client`.

If we set reasonably aggressive timeouts on the bus sockets, we should be able to avoid messages piling up, and blocking any requests / response threads.

To fix the HV sup_dude and performance_timings problems in HV, I'm basically going to:

1. Start doing buffered publishing. This will not block on any Socket IO in the request / response lifecycle.
2. Configure the batches to publish async on a background thread pool of size 1 (only one outstanding batch at a time, should be the default pool size).
3. Set the socket connect / read timeouts publishing to the bus to be pretty low, to shed load if things start to slow down.