### PR TITLE
Issue 26: inaccessible nsqd host causes memory leak and prevents shutdown [DATAINJ-2154]

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -69,7 +69,14 @@ public class Publisher extends BasePubSub {
             con.close();
         }
         con = new PubConnection(client, host, this);
-        con.connect(config);
+        try {
+            con.connect(config);
+        }
+        catch(IOException e) {
+            con.close();
+            con = null;
+            throw e;
+        }
         logger.info("publisher connected:{}", host);
     }
 

--- a/src/main/java/com/sproutsocial/nsq/SubConnection.java
+++ b/src/main/java/com/sproutsocial/nsq/SubConnection.java
@@ -6,6 +6,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+/**
+ * Note, the constructor registers a repeating task in the scheduler. The caller is responsible for invoking
+ * the close method when they are done with the object.
+ */
 class SubConnection extends Connection {
 
     private final MessageHandler handler;

--- a/src/main/java/com/sproutsocial/nsq/Subscription.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscription.java
@@ -53,13 +53,17 @@ class Subscription extends BasePubSub {
         }
         for (HostAndPort activeHost : activeHosts) {
             if (!connectionMap.containsKey(activeHost)) {
+                SubConnection con = null;
                 try {
                     logger.info("adding new connection:{} topic:{}", activeHost, topic);
-                    SubConnection con = new SubConnection(client, activeHost, this);
+                    con = new SubConnection(client, activeHost, this);
                     con.connect(subscriber.getConfig());
                     connectionMap.put(activeHost, con);
                 }
                 catch (Exception e) {
+                    if(con != null) {
+                        con.close();
+                    }
                     logger.error("error connecting to:{}", activeHost, e);
                 }
             }

--- a/src/test/java/com/sproutsocial/nsq/ObservedConnectionClient.java
+++ b/src/test/java/com/sproutsocial/nsq/ObservedConnectionClient.java
@@ -1,0 +1,31 @@
+package com.sproutsocial.nsq;
+
+/**
+ * Helper class for observing Client behavior in unit tests.
+ */
+class ObservedConnectionClient extends Client {
+
+    private int openConnections = 0;
+    private boolean connectionClosedCalled;
+
+    @Override
+    void addSubConnection(SubConnection subCon) {
+        super.addSubConnection(subCon);
+        this.openConnections++;
+    }
+
+    @Override
+    void connectionClosed(SubConnection closedCon) {
+        super.connectionClosed(closedCon);
+        this.openConnections--;
+        this.connectionClosedCalled = true;
+    }
+
+    boolean allSubConnectionsClosed() {
+        return this.openConnections == 0;
+    }
+
+    boolean connectionClosedCalled() {
+        return this.connectionClosedCalled;
+    }
+}

--- a/src/test/java/com/sproutsocial/nsq/SubConnectionInvalidHostTest.java
+++ b/src/test/java/com/sproutsocial/nsq/SubConnectionInvalidHostTest.java
@@ -1,0 +1,59 @@
+package com.sproutsocial.nsq;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.powermock.api.mockito.PowerMockito.methods;
+import static org.powermock.api.mockito.PowerMockito.suppress;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SubConnection.class)
+@PowerMockIgnore({"javax.management.*"})
+public class SubConnectionInvalidHostTest {
+
+    @Before
+    public void beforeClass() {
+        suppress(methods(SubConnection.class, "writeCommand"));
+        suppress(methods(SubConnection.class, "flush"));
+        suppress(methods(SubConnection.class, "scheduleAtFixedRate"));
+    }
+
+    @Test
+    public void testConnectInvalidHostname() {
+        ObservedConnectionClient client = new ObservedConnectionClient();
+        try {
+            Subscription subscription = Mockito.mock(Subscription.class);
+            Mockito.when(subscription.getSubscriber())
+                   .thenReturn(Mockito.mock(Subscriber.class));
+            SubConnection subConnection = new SubConnection(client,
+                    HostAndPort.fromString("this-is-unknown-hostname:5555"), subscription);
+
+            Config config = Mockito.mock(Config.class);
+            try {
+                subConnection.connect(config);
+                fail("IOException expected");
+            } catch (IOException ok) {
+            }
+            finally {
+                subConnection.close();
+            }
+
+            Thread.sleep(3000L);
+
+            assertTrue(client.allSubConnectionsClosed());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            assertTrue(client.stop());
+        }
+    }
+}

--- a/src/test/java/com/sproutsocial/nsq/SubscriptionInvalidHostTest.java
+++ b/src/test/java/com/sproutsocial/nsq/SubscriptionInvalidHostTest.java
@@ -1,0 +1,57 @@
+package com.sproutsocial.nsq;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.methods;
+import static org.powermock.api.mockito.PowerMockito.suppress;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SubConnection.class)
+@PowerMockIgnore({"javax.management.*"})
+public class SubscriptionInvalidHostTest {
+
+    @Before
+    public void beforeClass() {
+        suppress(methods(SubConnection.class, "writeCommand"));
+        suppress(methods(SubConnection.class, "flush"));
+        suppress(methods(SubConnection.class, "scheduleAtFixedRate"));
+    }
+
+    @Test
+    public void testInvalidNsqdHost__allConnectionsClosed() {
+        ObservedConnectionClient client = new ObservedConnectionClient();
+
+        try {
+            // must implement Subscriber because cannot mock package protected getConfig()
+            Subscriber subscriber = new Subscriber(client, 5, 5);
+            Subscription subscription = new Subscription(client, "topic", "channel", null, subscriber, 1);
+
+            Set<HostAndPort> activeHosts = new HashSet<HostAndPort>(
+                    Collections.singletonList(HostAndPort.fromString("this-is-unknown-hostname:5555")));
+            subscription.checkConnections(activeHosts);
+
+            try {
+                Thread.sleep(3000L);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            assertEquals(0, subscription.getConnectionCount());
+            assertTrue(client.allSubConnectionsClosed());
+        }
+        finally {
+            assertTrue(client.stop());
+        }
+    }
+}


### PR DESCRIPTION
* Modified code to close SubConnection and PubConnection on error
* Added unit tests for testing connection closed with invalid host

Note, this PR and the PR https://github.com/sproutsocial/nsq-j/pull/27 introduce the class `ObservedConnectionClient`. The class is the same