### PR TITLE
Release 1.0, improve shutdown. [DATAINJ-2154]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Add a dependency using Maven
 <dependency>
   <groupId>com.sproutsocial</groupId>
   <artifactId>nsq-j</artifactId>
-  <version>0.9.4</version>
+  <version>1.0</version>
 </dependency>
 ```
 or Gradle
 ```
 dependencies {
-  compile 'com.sproutsocial:nsq-j:0.9.4'
+  compile 'com.sproutsocial:nsq-j:1.0'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>0.9.4</version>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>
@@ -98,6 +98,7 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+            <!-- uncomment when uploading to maven central
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
@@ -112,6 +113,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
         </plugins>
     </build>
 

--- a/src/main/java/com/sproutsocial/nsq/Client.java
+++ b/src/main/java/com/sproutsocial/nsq/Client.java
@@ -194,4 +194,8 @@ public class Client {
         return gson;
     }
 
+    synchronized boolean isLonePublisher(Publisher publisher) {
+        return subscribers.isEmpty() && publishers.size() == 1 && publishers.iterator().next() == publisher;
+    }
+
 }

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -196,6 +196,9 @@ public class Publisher extends BasePubSub {
         if (batchExecutor != null) {
             Util.shutdownAndAwaitTermination(batchExecutor, 40, TimeUnit.MILLISECONDS);
         }
+        if (client.isLonePublisher(this)) { // convenience, prevents needing to call client.stop() to stop all threads
+            Util.shutdownAndAwaitTermination(client.getSchedExecutor(), 40, TimeUnit.MILLISECONDS);
+        }
     }
 
     public synchronized int getFailoverDurationSecs() {


### PR DESCRIPTION
`Client::stop` is the right way to shut everything down, `Publisher::stop` now does the same thing if you only create one Publisher.

Release 1.0