### PR TITLE
Add ability to requeue with delay. [custcare-1352]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/src/main/java/com/sproutsocial/nsq/Message.java
+++ b/src/main/java/com/sproutsocial/nsq/Message.java
@@ -16,6 +16,8 @@ public interface Message {
 
     void requeue();
 
+    void requeue(int delayMillis);
+
     void touch();
 
 }

--- a/src/main/java/com/sproutsocial/nsq/NSQMessage.java
+++ b/src/main/java/com/sproutsocial/nsq/NSQMessage.java
@@ -54,6 +54,11 @@ class NSQMessage implements Message {
     }
 
     @Override
+    public void requeue(int delayMillis) {
+        connection.requeue(id, delayMillis);
+    }
+
+    @Override
     public void touch() {
         connection.touch(id);
     }

--- a/src/main/java/com/sproutsocial/nsq/SubConnection.java
+++ b/src/main/java/com/sproutsocial/nsq/SubConnection.java
@@ -57,8 +57,12 @@ class SubConnection extends Connection {
     }
 
     public synchronized void requeue(String id) {
+        requeue(id, 0);
+    }
+
+    public synchronized void requeue(String id, int delayMillis) {
         try {
-            writeCommand("REQ", id, 0);
+            writeCommand("REQ", id, delayMillis);
             requeuedCount++;
             messageDone();
         }


### PR DESCRIPTION
as described [here](https://nsq.io/clients/tcp_protocol_spec.html#req) and [here](https://nsq.io/clients/tcp_protocol_spec.html#req)

the nsq docs say we should be doing this automatically when you requeue with no delay argument, but i don't want to make any breaking changes here.