### PR TITLE
Add Round Robbin Publishing for k8's use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ If a failover host is provided, it will be used when messages are not able to be
 After a time period of 5 minutes, the next publish will attempt to reconnect to the primary. 
 If you wish to change this failback timer, simply use `Publisher#setFailoverDurationSecs`.  
 
-### Round robin publishing
+### Round-robin publishing
 
 ```java
 Publisher publisher = new Publisher("nsqd-host-1:4150,nsqd-host-2:4150,nsqd-host-3:4150");
 ```
-We support round robin publishing with a simple configuration change.  Providing a comma 
+We support round-robin publishing with a simple configuration change.  Providing a comma 
 separated list of hosts for either the primary or failover host fields will activate round robin publishing. 
 
 Round robin works by rotation thru all unique host+ports that are configured.  If a publish fails, the connection 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ after nsqd responds `OK`
 You can batch messages manually and publish them all at once with
 `publish(String topic, List<byte[]> messages)`
 
+### Failover publishing
+```java
+Publisher publisher = new Publisher("nsqd-host", "nsqd-failover-host");
+```
+If a failover host is provided, it will be used when messages are not able to be written to the primary.  
+
+After a time period of 5 minutes, the next publish will attempt to reconnect to the primary. 
+If you wish to change this failback timer, simply use `Publisher#setFailoverDurationSecs`.  
+
+### Round robin publishing
+
+```java
+Publisher publisher = new Publisher("nsqd-host-1:4150,nsqd-host-2:4150,nsqd-host-3:4150");
+```
+We support round robin publishing with a simple configuration change.  Providing a comma 
+separated list of hosts for either the primary or failover host fields will activate round robin publishing. 
+
+Round robin works by rotation thru all unique host+ports that are configured.  If a publish fails, the connection 
+is closed and the host is marked as failed for 5 minutes.  After that time, it will try to reconnect to that host.  
+A failed publish will be retried until all hosts are marked as failed.  
+
+You can adjust the failed timer by using `Publisher#setFailoverDurationSecs`.
+
+Round Robin publishing is appropriate for use cases where nsqd is deployed on a different host than the publisher.
+This is most comon in autoscaling or ephemeral environemnts.  In such cases its desirable to both have 
+well scaled, persistent nsq infrastructure and a single configuration that will make use of that hardware.   
+
 ## Subscribe
 ```java
 public class PubExample {

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/sproutsocial/nsq/FailoverPublisher.java
+++ b/src/main/java/com/sproutsocial/nsq/FailoverPublisher.java
@@ -1,0 +1,175 @@
+package com.sproutsocial.nsq;
+
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.sproutsocial.nsq.Util.checkArgument;
+import static com.sproutsocial.nsq.Util.checkNotNull;
+
+@ThreadSafe
+public class FailoverPublisher extends BasePubSub implements PublisherInterface {
+
+    private final HostAndPort nsqd;
+    private final HostAndPort failoverNsqd;
+    private Publisher parent;
+    private PubConnection con;
+    private boolean isFailover = false;
+    private long failoverStart;
+    private int failoverDurationSecs = 300;
+
+    private static final int DEFAULT_MAX_BATCH_SIZE = 16 * 1024;
+    private static final int DEFUALT_MAX_BATCH_DELAY = 300;
+
+    private static final Logger logger = LoggerFactory.getLogger(FailoverPublisher.class);
+
+    public FailoverPublisher(Client client, String nsqd, String failoverNsqd, Publisher parent) {
+        super(client);
+        this.nsqd = HostAndPort.fromString(nsqd).withDefaultPort(4150);
+        this.failoverNsqd = failoverNsqd != null ? HostAndPort.fromString(failoverNsqd).withDefaultPort(4150) : null;
+        this.parent = parent;
+    }
+
+
+    @GuardedBy("this")
+    private void checkConnection() throws IOException {
+        if (con == null) {
+            if (isStopping) {
+                throw new NSQException("publisher stopped");
+            }
+            connect(nsqd);
+        }
+        else if (isFailover && Util.clock() - failoverStart > failoverDurationSecs * 1000) {
+            isFailover = false;
+            connect(nsqd);
+            logger.info("using primary nsqd");
+        }
+    }
+
+    @GuardedBy("this")
+    private void connect(HostAndPort host) throws IOException {
+        if (con != null) {
+            con.close();
+        }
+        con = new PubConnection(client, host, parent);
+        try {
+            con.connect(config);
+        }
+        catch(IOException e) {
+            con.close();
+            con = null;
+            throw e;
+        }
+        logger.info("publisher connected:{}", host);
+    }
+
+    @Override
+    public synchronized void connectionClosed(PubConnection closedCon) {
+        if (con == closedCon) {
+            con = null;
+            logger.debug("removed closed publisher connection:{}", closedCon.getHost());
+        }
+    }
+
+    @Override
+    public synchronized void publish(String topic, byte[] data) {
+        checkNotNull(topic);
+        checkNotNull(data);
+        checkArgument(data.length > 0);
+        try {
+            checkConnection();
+            con.publish(topic, data);
+        }
+        catch (Exception e) {
+            logger.error("publish error with:{}", isFailover ? failoverNsqd : nsqd, e);
+            publishFailover(topic, data);
+        }
+    }
+
+    @Override
+    public synchronized void publishDeferred(String topic, byte[] data, long delay, TimeUnit unit) {
+        checkNotNull(topic);
+        checkNotNull(data);
+        checkArgument(data.length > 0);
+        checkArgument(delay > 0);
+        checkNotNull(unit);
+        try {
+            checkConnection();
+            con.publishDeferred(topic, data, unit.toMillis(delay));
+        }
+        catch (Exception e) {
+            //deferred publish never fails over
+            throw new NSQException("deferred publish failed", e);
+        }
+    }
+
+    @Override
+    public synchronized void publish(String topic, List<byte[]> dataList) {
+        checkNotNull(topic);
+        checkNotNull(dataList);
+        checkArgument(dataList.size() > 0);
+        try {
+            checkConnection();
+            con.publish(topic, dataList);
+        }
+        catch (Exception e) {
+            logger.error("publish error with:{}", isFailover ? failoverNsqd : nsqd, e);
+            for (byte[] data : dataList) {
+                publishFailover(topic, data);
+            }
+        }
+    }
+
+    @GuardedBy("this")
+    private void publishFailover(String topic, byte[] data) {
+        try {
+            if (failoverNsqd == null) {
+                logger.warn("publish failed but no failoverNsqd configured. Will wait and retry once.");
+                Util.sleepQuietly(10000); //could do exponential backoff or make configurable
+                connect(nsqd);
+            }
+            else if (!isFailover) {
+                failoverStart = Util.clock();
+                isFailover = true;
+                connect(failoverNsqd);
+                logger.info("using failover nsqd:{}", failoverNsqd);
+            }
+            con.publish(topic, data);
+        }
+        catch (Exception e) {
+            Util.closeQuietly(con);
+            con = null;
+            isFailover = false;
+            throw new NSQException("publish failed", e);
+        }
+    }
+
+
+    @Override
+    public synchronized void stop() {
+        super.stop();
+        Util.closeQuietly(con);
+        con = null;
+    }
+
+    @Override
+    public synchronized int getFailoverDurationSecs() {
+        return failoverDurationSecs;
+    }
+
+    @Override
+    public synchronized void setFailoverDurationSecs(int failoverDurationSecs) {
+        this.failoverDurationSecs = failoverDurationSecs;
+    }
+
+
+}

--- a/src/main/java/com/sproutsocial/nsq/PublisherInterface.java
+++ b/src/main/java/com/sproutsocial/nsq/PublisherInterface.java
@@ -1,0 +1,21 @@
+package com.sproutsocial.nsq;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public interface PublisherInterface {
+    void connectionClosed(PubConnection closedCon);
+
+    void publish(String topic, byte[] data);
+
+    void publishDeferred(String topic, byte[] data, long delay, TimeUnit unit);
+
+    void publish(String topic, List<byte[]> dataList);
+
+    void stop();
+
+    int getFailoverDurationSecs();
+
+    void setFailoverDurationSecs(int failoverDurationSecs);
+
+}

--- a/src/main/java/com/sproutsocial/nsq/RoundRobinPublisher.java
+++ b/src/main/java/com/sproutsocial/nsq/RoundRobinPublisher.java
@@ -1,0 +1,224 @@
+package com.sproutsocial.nsq;
+
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.sproutsocial.nsq.Util.checkArgument;
+import static com.sproutsocial.nsq.Util.checkNotNull;
+
+@ThreadSafe
+public class RoundRobinPublisher extends BasePubSub implements PublisherInterface {
+    private Publisher parent;
+
+    private class ConnectionDetails {
+        HostAndPort hostAndPort;
+        PubConnection con = null;
+        boolean isFailover = false;
+        long failoverStart = 0;
+
+        public ConnectionDetails(String hostAndPort) {
+            this.hostAndPort = HostAndPort.fromString(hostAndPort).withDefaultPort(4150);
+        }
+
+        /**
+         * @return true if this host is ready to receive data
+         */
+        protected synchronized boolean makeReady() {
+            if (con == null) {
+                if (parent.isStopping) {
+                    throw new NSQException("publisher stopped");
+                }
+                return connectAttempt();
+            } else if (isFailover && canAttemptRecovery()) {
+                isFailover = false;
+                connectAttempt();
+                logger.info("using primary nsqd");
+                return true;
+            }
+            return !(isFailover || con == null);
+        }
+
+        private boolean canAttemptRecovery() {
+            return Util.clock() - failoverStart > failoverDurationSecs * 1000;
+        }
+
+        private boolean connectAttempt() {
+            if (con != null) {
+                con.close();
+            }
+            con = new PubConnection(client, this.hostAndPort, parent);
+            try {
+                con.connect(config);
+            } catch (IOException e) {
+                con.close();
+                con = null;
+                isFailover = true;
+                failoverStart = Util.clock();
+                logger.warn("Failed to connect to {}, will retry later", hostAndPort);
+                return false;
+            }
+            logger.info("publisher connected:{}", hostAndPort);
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ConnectionDetails that = (ConnectionDetails) o;
+            return hostAndPort.equals(that.hostAndPort);
+        }
+
+        @Override
+        public int hashCode() {
+            return hostAndPort.hashCode();
+        }
+
+
+        @Override
+        public String toString() {
+            return "ConnectionDetails{" +
+                    "hostAndPort=" + hostAndPort +
+                    '}';
+        }
+
+        protected synchronized void markFailure() {
+            con = null;
+            isFailover = true;
+            failoverStart = Util.clock();
+            logger.warn("Failed to connect to {}, will retry later", hostAndPort);
+        }
+
+        public void close() {
+            Util.closeQuietly(con);
+            con = null;
+        }
+    }
+
+    private final List<ConnectionDetails> daemonList;
+    private int nextDaemonIndex = 0;
+    private int failoverDurationSecs = 300;
+
+    private static final Logger logger = LoggerFactory.getLogger(RoundRobinPublisher.class);
+
+    public RoundRobinPublisher(Client client, String nsqd, String failoverNsqd, Publisher parent) {
+        super(client);
+        this.parent = parent;
+        Set<ConnectionDetails> connectionDetails = new HashSet<ConnectionDetails>();
+        daemonList = Collections.unmodifiableList(getConnectionDetails(nsqd, failoverNsqd, connectionDetails));
+    }
+
+    private List<ConnectionDetails> getConnectionDetails(String nsqd, String failoverNsqd, Set<ConnectionDetails> connectionDetails) {
+        for (String host : nsqd.split(",")) {
+            connectionDetails.add(new ConnectionDetails(host));
+        }
+        if (failoverNsqd != null) {
+            for (String host : failoverNsqd.split(",")) {
+                connectionDetails.add(new ConnectionDetails(host));
+            }
+        }
+        return new ArrayList<ConnectionDetails>(connectionDetails);
+    }
+
+    @Override
+    public synchronized void connectionClosed(PubConnection closedCon) {
+        for (ConnectionDetails daemon : daemonList) {
+            if (daemon.con == closedCon) {
+                daemon.con = null;
+                logger.debug("removed closed publisher connection:{}", closedCon.getHost());
+            }
+        }
+    }
+
+    @Override
+    public synchronized void publish(String topic, byte[] data) {
+        checkNotNull(topic);
+        checkNotNull(data);
+        checkArgument(data.length > 0);
+        ConnectionDetails nextDaemon = getNextDaemon();
+        try {
+            nextDaemon.con.publish(topic, data);
+        } catch (Exception e) {
+            nextDaemon.markFailure();
+            logger.error("publish error with:{}", nextDaemon, e);
+            publish(topic, data);//Recurse to get the next daemon and try again
+        }
+    }
+
+    @GuardedBy("this")
+    private ConnectionDetails getNextDaemon() {
+        for (int attempts = 0; attempts < daemonList.size(); attempts++) {
+            ConnectionDetails candidate = daemonList.get(nextDaemonIndex);
+            if (candidate.makeReady()) {
+                return candidate;
+            }
+            nextDaemonIndex++;
+            if (nextDaemonIndex >= daemonList.size()) {
+                nextDaemonIndex = 0;
+            }
+        }
+        throw new NSQException("publish failed: Unable to establish a connection with any NSQ host: " + daemonList);
+    }
+
+    @Override
+    public synchronized void publishDeferred(String topic, byte[] data, long delay, TimeUnit unit) {
+        checkNotNull(topic);
+        checkNotNull(data);
+        checkArgument(data.length > 0);
+        checkArgument(delay > 0);
+        checkNotNull(unit);
+        ConnectionDetails nextDaemon = getNextDaemon();
+        try {
+            nextDaemon.con.publishDeferred(topic, data, unit.toMillis(delay));
+        } catch (Exception e) {
+            nextDaemon.markFailure();
+            //deferred publish never fails over
+            throw new NSQException("deferred publish failed", e);
+        }
+    }
+
+    @Override
+    public synchronized void publish(String topic, List<byte[]> dataList) {
+        checkNotNull(topic);
+        checkNotNull(dataList);
+        checkArgument(dataList.size() > 0);
+        ConnectionDetails nextDaemon = getNextDaemon();
+        try {
+            nextDaemon.con.publish(topic, dataList);
+        } catch (Exception e) {
+            nextDaemon.markFailure();
+            logger.error("publish error with:{}", nextDaemon, e);
+            publish(topic, dataList);//Recurse to get next
+        }
+    }
+
+
+    @Override
+    public synchronized void stop() {
+        super.stop();
+        for (ConnectionDetails daemon : daemonList) {
+            daemon.close();
+        }
+    }
+
+    @Override
+    public synchronized int getFailoverDurationSecs() {
+        return failoverDurationSecs;
+    }
+
+    @Override
+    public synchronized void setFailoverDurationSecs(int failoverDurationSecs) {
+        this.failoverDurationSecs = failoverDurationSecs;
+    }
+
+}

--- a/src/test/java/com/sproutsocial/nsq/RoundRobbinIT.java
+++ b/src/test/java/com/sproutsocial/nsq/RoundRobbinIT.java
@@ -1,0 +1,130 @@
+package com.sproutsocial.nsq;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+//run one test: mvn "-Dit.test=PublishIT#testSnappy" verify
+
+public class RoundRobbinIT extends SubscribeBase {
+
+    public static final String PUBTEST = "pubtest";
+    public static final String MPUBTEST = "mpubtest";
+    public static final int MAX_MSG_LEN = 20;
+    public static final int MESSAGES_TO_SEND = 50;
+    private boolean usePublishSoon = false;
+
+    private void send(Publisher publisher, String topic, List<String> msgs, float delayChance, int maxDelay) {
+        int count = 0;
+        for (String msg : msgs) {
+            if (random.nextFloat() < delayChance) {
+                Util.sleepQuietly(random.nextInt(maxDelay));
+            }
+            if (usePublishSoon) {
+                publisher.publishBuffered(topic, msg.getBytes());
+            } else {
+                publisher.publish(topic, msg.getBytes());
+            }
+            if (++count % 10 == 0) {
+                System.out.println("sent " + count + " msgs");
+            }
+        }
+    }
+
+    @Test
+    public void testPubSoon() throws Exception {
+        System.out.println("testPubSoon. random seed:" + seed);
+        usePublishSoon = true;
+        testPub(new Config(), MAX_MSG_LEN);
+        usePublishSoon = false;
+    }
+
+    @Test
+    public void testPub() throws Exception {
+        System.out.println("testPub. random seed:" + seed);
+        testPub(new Config(), MAX_MSG_LEN);
+    }
+
+    private void testPub(Config config, int maxMsgLen) throws Exception {
+
+        Subscriber subscriber = new Subscriber(10, "127.0.0.1");
+        subscriber.subscribe(PUBTEST, "tail" + this.usePublishSoon + "#ephemeral", handler);
+
+        Util.sleepQuietly(1000);
+
+        Publisher publisher = new Publisher("localhost,test_nsqd");
+        publisher.setConfig(config);
+        List<String> msgs = messages(MESSAGES_TO_SEND, maxMsgLen);
+        if (usePublishSoon) {
+            send(publisher, PUBTEST, msgs, 0.045f, 1200); //nice mix of delay/size at maxDelay=300 maxSize=16k
+        } else {
+            send(publisher, PUBTEST, msgs, 0.1f, 1000);
+        }
+
+        Util.sleepQuietly(1000);
+
+        // Since we are publishing round robin very rapidly, there is a good chance that messages will be delivered out of order.
+        // That is ok if you are using round robin publishing.
+        Collections.sort(received, new Comparator<String>() {
+            @Override
+            public int compare(String s, String anotherString) {
+                return s.compareTo(anotherString);
+            }
+        });
+        assertEquals(msgs, received);
+    }
+
+    @Test
+    public void testMultiPub() throws Exception {
+        System.out.println("testMultiPub. random seed:" + seed);
+        testMultiPub(new Config());
+    }
+
+    private void testMultiPub(Config config) throws Exception {
+        Subscriber subscriber = new Subscriber(10, "127.0.0.1");
+        subscriber.subscribe(MPUBTEST, "tailMulti#ephemeral", handler);
+
+        Util.sleepQuietly(1000);
+
+        Publisher publisher = new Publisher("localhost,test_nsqd");
+        publisher.setConfig(config);
+
+        List<String> sent = new ArrayList<String>();
+
+        int count = 0;
+        for (int i = 0; i < 4; i++) {
+            List<String> msgs = messages(10, MAX_MSG_LEN);
+            List<byte[]> msgData = new ArrayList<byte[]>(msgs.size());
+            for (String msg : msgs) {
+                msgData.add(msg.getBytes());
+            }
+            publisher.publish(MPUBTEST, msgData);
+            count += msgs.size();
+            sent.addAll(msgs);
+            System.out.println("mpub " + count);
+            Util.sleepQuietly(random.nextInt(500));
+        }
+
+        Util.sleepQuietly(1000);
+
+        //With round robbin, messages may arrive out of order.
+        Collections.sort(received, new Comparator<String>() {
+            @Override
+            public int compare(String s, String anotherString) {
+                return s.compareTo(anotherString);
+            }
+        });
+        Collections.sort(sent, new Comparator<String>() {
+            @Override
+            public int compare(String s, String anotherString) {
+                return s.compareTo(anotherString);
+            }
+        });
+        assertEquals(sent, received);
+    }
+}

--- a/src/test/java/com/sproutsocial/nsq/RoundRobbinIT.java
+++ b/src/test/java/com/sproutsocial/nsq/RoundRobbinIT.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 
 //run one test: mvn "-Dit.test=PublishIT#testSnappy" verify
 
-public class RoundRobbinIT extends SubscribeBase {
+public class RoundRobinIT extends SubscribeBase {
 
     public static final String PUBTEST = "pubtest";
     public static final String MPUBTEST = "mpubtest";
@@ -112,7 +112,7 @@ public class RoundRobbinIT extends SubscribeBase {
 
         Util.sleepQuietly(1000);
 
-        //With round robbin, messages may arrive out of order.
+        //With round robin, messages may arrive out of order.
         Collections.sort(received, new Comparator<String>() {
             @Override
             public int compare(String s, String anotherString) {


### PR DESCRIPTION
Having a single configured publisher is great when nsqd is running locally, or when there is a relatively small message volume being sent to a centralized broker.  But that breaks down when you have a deployment on K8's which a relatively large message volume.  

A reasonable pattern in k8's land is to create a nsqd server (and a failover) outside of the k8's cluster to ensure they are durable to pod restarts, autoscaling, etc.  Then configure publishers to send to that host instead of localhost.  
This breaks down once we start to bump into high volume topics or topics with batch consumers.  Such situations depended on nsq's distributed architecture.  

We considered putting a load balancer in front of several nsqd.  But that would only works well if the number of `Publisher`'s was much greater than the number of nsqd.  If the number of Publishers are close, there is a reasonably high chance for unlucky message distribution.  

Round robin solves this by allowing many nsdq to be configured, and for them to share the load from each publisher.  This solution does not require an API change, and allows for configuration to dictate if round robin should be used.  