### PR TITLE
Idea sketch / concept art: Round Robin Balancing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -390,6 +390,12 @@ abstract class Connection extends BasePubSub implements Closeable {
         return connectionState.get();
     }
 
+    public void maybeAttemptRetry() {
+        if (isReadyForRetry()) {
+            retryConnection();
+        }
+    }
+
     public boolean isReadyForRetry() {
         return failureState.get().map(f -> f.isReadyForRetry(Util.clock())).orElse(false);
     }

--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -69,7 +69,7 @@ abstract class Connection extends BasePubSub implements Closeable {
     protected DataOutputStream out;
     protected DataInputStream in;
     private volatile boolean isReading = true;
-    // TODO: Think about concurrency control for these.
+
     protected final AtomicReference<State> connectionState;
     protected final AtomicReference<Optional<FailureState>> failureState;
 

--- a/src/main/java/com/sproutsocial/nsq/FailoverBalanceStrategy.java
+++ b/src/main/java/com/sproutsocial/nsq/FailoverBalanceStrategy.java
@@ -1,0 +1,14 @@
+package com.sproutsocial.nsq;
+
+import java.util.Optional;
+
+/**
+ * A publish balance strategy that always tries to publish to the first
+ * healthy connection that's available, in descending order.
+ */
+public class FailoverBalanceStrategy implements PublisherBalanceStrategy {
+    @Override
+    public Optional<PubConnection> getConnectionFrom(PublisherConnectionPool pool) {
+        return pool.getHealthyConnectionAt(0);
+    }
+}

--- a/src/main/java/com/sproutsocial/nsq/PubConnection.java
+++ b/src/main/java/com/sproutsocial/nsq/PubConnection.java
@@ -44,14 +44,6 @@ class PubConnection extends Connection {
     @Override
     public void close() {
         super.close();
-        if (!publisher.isStopping) {
-            //be paranoid about locks, we only care that this happens sometime soon
-            client.getSchedExecutor().execute(new Runnable() {
-                public void run() {
-                    publisher.connectionClosed(PubConnection.this);
-                }
-            });
-        }
     }
 
     @Override

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -150,9 +150,9 @@ public class Publisher extends BasePubSub {
 
         PubConnection connection = null;
         while (true) {
+            connection = balanceStrategy.getConnectionFrom(pool)
+                .orElseThrow(() -> new NSQException("All publisher connections exhausted, failing to publish message"));
             try {
-                connection = balanceStrategy.getConnectionFrom(pool)
-                    .orElseThrow(() -> new NSQException("All publisher connections exhausted, failing to publish message"));
                 fn.accept(connection);
                 return;
             } catch (Exception e) {

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -146,6 +146,8 @@ public class Publisher extends BasePubSub {
     }
 
     private void withConnection(Consumer<PubConnection> fn) {
+        pool.startIfStopped(config);
+
         PubConnection connection = null;
         while (true) {
             try {

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -59,6 +59,7 @@ public class Publisher extends BasePubSub {
         else if (isFailover && Util.clock() - failoverStart > failoverDurationSecs * 1000) {
             isFailover = false;
             connect(nsqd);
+            con.retryConnection();
             logger.info("using primary nsqd");
         }
     }
@@ -142,7 +143,7 @@ public class Publisher extends BasePubSub {
                 connect(nsqd);
             }
             else if (!isFailover) {
-                failoverStart = Util.clock();
+                con.failConnectionFor(failoverDurationSecs);
                 isFailover = true;
                 connect(failoverNsqd);
                 logger.info("using failover nsqd:{}", failoverNsqd);

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -50,34 +50,6 @@ public class Publisher extends BasePubSub {
         this(nsqd, null);
     }
 
-    @GuardedBy("this")
-    private void connect(HostAndPort host) throws IOException {
-        // TODO: Move this to the connection pool?
-        //
-        // if (con != null) {
-        //     con.close();
-        // }
-        // con = new PubConnection(client, host, this);
-        // try {
-        //     con.connect(config);
-        // }
-        // catch(IOException e) {
-        //     con.close();
-        //     con = null;
-        //     throw e;
-        // }
-        // logger.info("publisher connected:{}", host);
-    }
-
-    public synchronized void connectionClosed(PubConnection closedCon) {
-        // TODO: Move this to the connection pool?
-        // 
-        // if (con == closedCon) {
-        //     con = null;
-        //     logger.debug("removed closed publisher connection:{}", closedCon.getHost());
-        // }
-    }
-
     public synchronized void publish(String topic, byte[] data) {
         checkNotNull(topic);
         checkNotNull(data);
@@ -120,30 +92,6 @@ public class Publisher extends BasePubSub {
                     throw new RuntimeException(e);
                 }
             });
-    }
-
-    @GuardedBy("this")
-    private void publishFailover(String topic, byte[] data) {
-        // try {
-        //     if (failoverNsqd == null) {
-        //         logger.warn("publish failed but no failoverNsqd configured. Will wait and retry once.");
-        //         Util.sleepQuietly(10000); //could do exponential backoff or make configurable
-        //         connect(nsqd);
-        //     }
-        //     else if (!isFailover) {
-        //         con.failConnectionFor(failoverDurationSecs);
-        //         isFailover = true;
-        //         connect(failoverNsqd);
-        //         logger.info("using failover nsqd:{}", failoverNsqd);
-        //     }
-        //     con.publish(topic, data);
-        // }
-        // catch (Exception e) {
-        //     Util.closeQuietly(con);
-        //     con = null;
-        //     isFailover = false;
-        //     throw new NSQException("publish failed", e);
-        // }
     }
 
     public synchronized void publishBuffered(String topic, byte[] data) {

--- a/src/main/java/com/sproutsocial/nsq/PublisherBalanceStrategy.java
+++ b/src/main/java/com/sproutsocial/nsq/PublisherBalanceStrategy.java
@@ -1,0 +1,7 @@
+package com.sproutsocial.nsq;
+
+import java.util.Optional;
+
+public interface PublisherBalanceStrategy {
+    Optional<PubConnection> getConnectionFrom(PublisherConnectionPool pool);
+}

--- a/src/main/java/com/sproutsocial/nsq/PublisherConnectionPool.java
+++ b/src/main/java/com/sproutsocial/nsq/PublisherConnectionPool.java
@@ -1,5 +1,8 @@
 package com.sproutsocial.nsq;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +21,8 @@ import net.jcip.annotations.GuardedBy;
  */
 
 public class PublisherConnectionPool {
+    private static final Logger logger = LoggerFactory.getLogger(PublisherConnectionPool.class);
+
     private final Client client;
     private final Publisher publisher;
     private final List<HostAndPort> nsqdHosts;
@@ -53,6 +58,7 @@ public class PublisherConnectionPool {
 
     @GuardedBy("Publisher")
     public void start(Config config) {
+        logger.info("nsq-j publisher connection pool starting");
         for (final HostAndPort host : nsqdHosts) {
             final PubConnection connection = new PubConnection(client, host, publisher);
             try {
@@ -63,13 +69,13 @@ public class PublisherConnectionPool {
             }
             connections.add(connection);
         }
+        started = true;
     }
 
     @GuardedBy("Publisher")
     public void startIfStopped(Config config) {
         if (!started) {
             start(config);
-            started = true;
         }
     }
 

--- a/src/main/java/com/sproutsocial/nsq/PublisherConnectionPool.java
+++ b/src/main/java/com/sproutsocial/nsq/PublisherConnectionPool.java
@@ -1,22 +1,28 @@
 package com.sproutsocial.nsq;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import net.jcip.annotations.GuardedBy;
+
 /**
  * Manages connection state and pooling for nsqd instances for publishers. Fed
- * into a {@link com.sproutsocial.nsq.BalanceStrategy}, which is responsible for
+ * into a {@link com.sproutsocial.nsq.PublisherBalanceStrategy}, which is responsible for
  * connection selection at message publishing time.
  *
  * Each {@link com.sproutsocial.nsq.PubConnection} is pinned to a single publisher,
  * and PubConnection access is all thread-safe.
  */
+
 public class PublisherConnectionPool {
     private final Client client;
     private final Publisher publisher;
     private final List<HostAndPort> nsqdHosts;
     private final List<PubConnection> connections;
+
+    private boolean started;
 
     public PublisherConnectionPool(final Client client,
                                    final Publisher publisher,
@@ -25,21 +31,56 @@ public class PublisherConnectionPool {
         this.publisher = publisher;
         this.nsqdHosts = nsqdHosts;
         this.connections = new ArrayList<>();
+        this.started = false;
     }
 
+    @GuardedBy("Publisher")
     public int getHealthyConnectionCount() {
         return (int)connections.stream()
             .filter(conn -> conn.getConnectionState() == Connection.State.ESTABLISHED)
             .count();
     }
 
+    @GuardedBy("Publisher")
     public Optional<PubConnection> getHealthyConnectionAt(final int index) {
         return connections.stream()
+            .map(conn -> {
+                    if (conn.isReadyForRetry()) {
+                        conn.retryConnection();
+                    }
+                    return conn;
+                })
             .filter(conn -> conn.getConnectionState() == Connection.State.ESTABLISHED)
             .skip(index)
             .findFirst();
     }
 
+    @GuardedBy("Publisher")
     public void stop() {
+        for (final PubConnection connection : connections) {
+            connection.close();
+        }
+    }
+
+    @GuardedBy("Publisher")
+    public void start(Config config) {
+        for (final HostAndPort host : nsqdHosts) {
+            final PubConnection connection = new PubConnection(client, host, publisher);
+            try {
+                connection.connect(config);
+            } catch (IOException e) {
+                final long failDuration = 5_000; // TODO: Make this configurable?
+                connection.failConnectionFor(failDuration);
+            }
+            connections.add(connection);
+        }
+    }
+
+    @GuardedBy("Publisher")
+    public void startIfStopped(Config config) {
+        if (!started) {
+            start(config);
+            started = true;
+        }
     }
 }

--- a/src/main/java/com/sproutsocial/nsq/PublisherConnectionPool.java
+++ b/src/main/java/com/sproutsocial/nsq/PublisherConnectionPool.java
@@ -1,0 +1,45 @@
+package com.sproutsocial.nsq;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Manages connection state and pooling for nsqd instances for publishers. Fed
+ * into a {@link com.sproutsocial.nsq.BalanceStrategy}, which is responsible for
+ * connection selection at message publishing time.
+ *
+ * Each {@link com.sproutsocial.nsq.PubConnection} is pinned to a single publisher,
+ * and PubConnection access is all thread-safe.
+ */
+public class PublisherConnectionPool {
+    private final Client client;
+    private final Publisher publisher;
+    private final List<HostAndPort> nsqdHosts;
+    private final List<PubConnection> connections;
+
+    public PublisherConnectionPool(final Client client,
+                                   final Publisher publisher,
+                                   final List<HostAndPort> nsqdHosts) {
+        this.client = client;
+        this.publisher = publisher;
+        this.nsqdHosts = nsqdHosts;
+        this.connections = new ArrayList<>();
+    }
+
+    public int getHealthyConnectionCount() {
+        return (int)connections.stream()
+            .filter(conn -> conn.getConnectionState() == Connection.State.ESTABLISHED)
+            .count();
+    }
+
+    public Optional<PubConnection> getHealthyConnectionAt(final int index) {
+        return connections.stream()
+            .filter(conn -> conn.getConnectionState() == Connection.State.ESTABLISHED)
+            .skip(index)
+            .findFirst();
+    }
+
+    public void stop() {
+    }
+}

--- a/src/main/java/com/sproutsocial/nsq/RoundRobinBalanceStrategy.java
+++ b/src/main/java/com/sproutsocial/nsq/RoundRobinBalanceStrategy.java
@@ -1,0 +1,22 @@
+package com.sproutsocial.nsq;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Balance strategy that attempts to hand out nsqd connections in a round-robin /
+ * even fashion by cycling through connections that are healthy.
+ */
+public class RoundRobinBalanceStrategy implements PublisherBalanceStrategy {
+    private AtomicLong counter;
+
+    public RoundRobinBalanceStrategy() {
+        this.counter = new AtomicLong(0L);
+    }
+
+    @Override
+    public Optional<PubConnection> getConnectionFrom(PublisherConnectionPool pool) {
+        final long index = counter.getAndIncrement();
+        return pool.getHealthyConnectionAt(index);
+    }
+}


### PR DESCRIPTION
This is untested "concept art" to demonstrate some of the ideas of how we might add round-robin publishing to the client. There are definitely concurrency things to work out (misuse of atomics), as well as some potentially slow paths along the publishing path like using streams.

This is meant more just to get some core ideas across, that we can refine and iterate on together:

- I think a lot of the complexity of the existing mainline publisher is due to connection failures being tracked at the completely wrong level (on the Publisher directly). My draft attempts to move connection failure state down to the connection itself.
- I played around with a PublisherConnectionPool abstraction to manage handing out connections.
- Relocating these concerns enabled keeping the PublisherBalanceStrategy interface really slim: Just one method that hands out connections from the pool.