### PR TITLE
LIS-5351: Add initial GitHub actions build to cut a release

### DIFF
--- a/.github/workflows/release-and-publish-artifacts.yml
+++ b/.github/workflows/release-and-publish-artifacts.yml
@@ -2,18 +2,19 @@ name: release and push to central
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup build dependencies
         run: make setup
       - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: temurin
+          java-version: 8
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/release-and-publish-artifacts.yml
+++ b/.github/workflows/release-and-publish-artifacts.yml
@@ -1,0 +1,33 @@
+name: release and push to central
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup build dependencies
+        run: make setup
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Publish to the Maven Central Repository
+        run: make clean deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: "${{ github.workspace }}/target/*.jar"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ setup:
 test:
 	mvn verify
 
+deploy:
+	mvn --no-transfer-progress --batch-mode deploy
+
 docker_teardown:
 	$(SCRIPTS_DIR)/testCleanupDocker.sh
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,26 @@
                     <show>public</show>
                 </configuration>
             </plugin>
-            <plugin>
+	    <plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-gpg-plugin</artifactId>
+		<executions>
+		    <execution>
+			<id>sign-artifacts</id>
+			<phase>deploy</phase>
+			<goals>
+			    <goal>sign</goal>
+			</goals>
+			<configuration>
+			    <gpgArguments>
+				<arg>--pinentry-mode</arg>
+				<arg>loopback</arg>
+			    </gpgArguments>
+			</configuration>
+		    </execution>
+		</executions>
+	    </plugin>
+	    <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <version>1.6.12</version>
@@ -100,22 +119,6 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
-            <!-- uncomment when uploading to maven central
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            -->
         </plugins>
     </build>
 
@@ -222,5 +225,13 @@
         <developerConnection>scm:git:ssh://github.com:sproutsocial/nsq-j.git</developerConnection>
         <url>http://github.com/sproutsocial/nsq-j/tree/master</url>
     </scm>
+
+    <distributionManagement>
+	<repository>
+            <id>ossrh</id>
+            <name>Central Repository OSSRH</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+	</repository>
+    </distributionManagement>
 
 </project>


### PR DESCRIPTION
Triggers on a new tag being pushed.

1. Runs the build, and integration test suite.
2. Signs artifacts, and pushes to maven central.
3. Creates a new GitHub release.