### PR TITLE
LIS-5351: Add missing environment name

### DIFF
--- a/.github/workflows/release-and-publish-artifacts.yml
+++ b/.github/workflows/release-and-publish-artifacts.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release-env
     steps:
       - uses: actions/checkout@v3
       - name: Setup build dependencies


### PR DESCRIPTION
CI build needs access to the `release-env` environment, for secret access.