### PR TITLE
DP-4: Release nsq-j 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Add a dependency using Maven
 <dependency>
   <groupId>com.sproutsocial</groupId>
   <artifactId>nsq-j</artifactId>
-  <version>1.2</version>
+  <version>1.4</version>
 </dependency>
 ```
 or Gradle
 ```
 dependencies {
-  compile 'com.sproutsocial:nsq-j:1.2'
+  compile 'com.sproutsocial:nsq-j:1.4'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>1.4-beta1</version>
+    <version>1.4</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>


### PR DESCRIPTION
Now that we've burned in the release candidate successfully across several deployments, let's take this version out of 'beta'.