### PR TITLE
DP-12: Batch MPUB calls should retry using sequential publishing to preserve old client behavior

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -125,7 +125,12 @@ public class Publisher extends BasePubSub {
         } catch (Exception e) {
             logger.error("publish error", e);
             connectionDetails.markFailure();
-            publish(topic, dataList);
+            // We publish sequentially when we have an MPUB failure to
+            // help cover cases where perhaps the total payload size of the
+            // MPUB exceeded the nsqd -max-body-size or -max-msg-size.
+            for (final byte[] data : dataList) {
+                publish(topic, data);
+            }
         }
     }
 

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -133,11 +133,7 @@ public class Publisher extends BasePubSub {
             // the 'all-or-nothing' atomicity publishing guarantees of MPUB,
             // rather than optimizing for batch-publishing throughput only.
             for (final byte[] data : dataList) {
-                try {
-                    publish(topic, data);
-                } catch (Exception ex) {
-                    logger.error("failed to sequentially publish message after failed MPUB call call", ex);
-                }
+                publish(topic, data);
             }
         }
     }

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -128,8 +128,16 @@ public class Publisher extends BasePubSub {
             // We publish sequentially when we have an MPUB failure to
             // help cover cases where perhaps the total payload size of the
             // MPUB exceeded the nsqd -max-body-size or -max-msg-size.
+            //
+            // TODO: Perhaps make this configurable for clients that want
+            // the 'all-or-nothing' atomicity publishing guarantees of MPUB,
+            // rather than optimizing for batch-publishing throughput only.
             for (final byte[] data : dataList) {
-                publish(topic, data);
+                try {
+                    publish(topic, data);
+                } catch (Exception ex) {
+                    logger.error("failed to sequentially publish message after failed MPUB call call", ex);
+                }
             }
         }
     }

--- a/src/test/java/com/sproutsocial/nsq/PublisherWithFailoverDockerTestIT.java
+++ b/src/test/java/com/sproutsocial/nsq/PublisherWithFailoverDockerTestIT.java
@@ -3,7 +3,9 @@ package com.sproutsocial.nsq;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class PublisherWithFailoverDockerTestIT extends BaseDockerTestIT {
     private Subscriber subscriber;
@@ -57,6 +59,22 @@ public class PublisherWithFailoverDockerTestIT extends BaseDockerTestIT {
         Util.sleepQuietly(TimeUnit.SECONDS.toMillis(15));
 
         sendAndVerifyMessagesFromPrimary(publisher, handler);
+    }
+
+    @Test
+    public void failedBulkPublishesPublishToFailoverSequentially() {
+        final int maxBodySize = 5242880; // This is the default nsqd max body size for any nsqd TCP message
+        final int count = 30;
+        final int bytesPerMessage = (maxBodySize + 10) / count;
+        final List<String> messages = messages(count, bytesPerMessage);
+        final List<byte[]> batch = messages
+            .stream()
+            .map(String::getBytes)
+            .collect(Collectors.toList());
+        publisher.publish(topic, batch);
+        List<NSQMessage> receivedMessages = handler.drainMessagesOrTimeOut(messages.size());
+        validateReceivedAllMessages(messages, receivedMessages, true);
+        validateFromParticularNsqd(receivedMessages, 1);
     }
 
     @Test

--- a/src/test/java/com/sproutsocial/nsq/PublisherWithFailoverDockerTestIT.java
+++ b/src/test/java/com/sproutsocial/nsq/PublisherWithFailoverDockerTestIT.java
@@ -65,7 +65,7 @@ public class PublisherWithFailoverDockerTestIT extends BaseDockerTestIT {
     public void failedBulkPublishesPublishToFailoverSequentially() {
         final int maxBodySize = 5242880; // This is the default nsqd max body size for any nsqd TCP message
         final int count = 30;
-        final int bytesPerMessage = (maxBodySize + 10) / count;
+        final int bytesPerMessage = (maxBodySize + 10) / (count - 1);
         final List<String> messages = messages(count, bytesPerMessage);
         final List<byte[]> batch = messages
             .stream()

--- a/src/test/java/com/sproutsocial/nsq/RoundRobinDockerTestIT.java
+++ b/src/test/java/com/sproutsocial/nsq/RoundRobinDockerTestIT.java
@@ -158,8 +158,5 @@ public class RoundRobinDockerTestIT extends BaseDockerTestIT {
 
         List<NSQMessage> nsqMessages = handler.drainMessagesOrTimeOut(1);
         assertEquals(messages.get(0),new String(nsqMessages.get(0).getData()));
-
     }
-
-
 }


### PR DESCRIPTION
The old `Publisher` used to attempt batch publishing sequentially. This helps cover the case where someone accidentally publishes an `MPUB` batch that exceeds an nsqd's `-max-body-size` limit. 