### PR TITLE
DP-27: Add support for unsubscribing an active subscriber

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Subscriber.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscriber.java
@@ -96,6 +96,25 @@ public class Subscriber extends BasePubSub {
         sub.checkConnections(lookupTopic(topic));
     }
 
+    /**
+     * Unsubscribe from the current topic / channel subscription. This will stop the flow of messages to the
+     * previously registered message handler.
+     *
+     * NOTE: This will *not* delete the underlying channel that might have been created during the initial subscribe
+     * call.
+     */
+    public synchronized boolean unsubscribe(String topic, String channel) {
+        for (int i = 0; i < subscriptions.size(); i++) {
+            final Subscription sub = subscriptions.get(i);
+            if (sub.getTopic().equals(topic) && sub.getChannel().equals(channel)) {
+                sub.stop();
+                subscriptions.remove(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
     public synchronized void setMaxInFlight(String topic, String channel, int maxInFlight) {
         for (Subscription sub : subscriptions) {
             if (sub.getTopic().equals(topic) && sub.getChannel().equals(channel)) {

--- a/src/test/java/com/sproutsocial/nsq/SubscriberFocusedDockerTestIT.java
+++ b/src/test/java/com/sproutsocial/nsq/SubscriberFocusedDockerTestIT.java
@@ -39,6 +39,26 @@ public class SubscriberFocusedDockerTestIT extends BaseDockerTestIT {
     }
 
     @Test
+    public void unsubscribingSubscribers() {
+        TestMessageHandler handler = new TestMessageHandler();
+        Subscriber subscriber = startSubscriber(handler, "channelA", null);
+        List<String> batch1 = messages(20, 40);
+        List<String> batch2 = messages(20, 40);
+
+        send(topic, batch1, 0, 0, publisher);
+        Util.sleepQuietly(1000);
+        // Unsubscribe after the first batch.
+        Assert.assertTrue(subscriber.unsubscribe(topic, "channelA"));
+        send(topic, batch2, 0, 0, publisher);
+
+        Util.sleepQuietly(1000);
+
+        // Ensure we only get 20 messages, even though we sent 40.
+        List<NSQMessage> consumerMessages = handler.drainMessages(20);
+        Assert.assertEquals(20, consumerMessages.size());
+    }
+
+    @Test
     public void verySlowConsumer_allMessagesReceivedByResponsiveConsumer() {
         TestMessageHandler handler = new TestMessageHandler();
         NoAckReceiver delayHandler = new NoAckReceiver(8000);


### PR DESCRIPTION
The  NSQ `Subscriber` has no ability to remove a subscription. I need the ability to remove a subscription from a process that is still running, and relocate it to another process.

Pretty straight forward: Follows a similar pattern to how you can adjust the `maxInFlight` of a running `Subscriber`.

Tests: Integration. 