### PR TITLE
DP-44: Cleanup nsqd subscription connections correctly during unsubscribe.

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Subscriber.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscriber.java
@@ -104,15 +104,18 @@ public class Subscriber extends BasePubSub {
      * call.
      */
     public synchronized boolean unsubscribe(String topic, String channel) {
+        return unsubscribeSubscription(topic, channel) != null;
+    }
+
+    synchronized Subscription unsubscribeSubscription(String topic, String channel) {
         for (int i = 0; i < subscriptions.size(); i++) {
             final Subscription sub = subscriptions.get(i);
             if (sub.getTopic().equals(topic) && sub.getChannel().equals(channel)) {
                 sub.stop();
-                subscriptions.remove(i);
-                return true;
+                return subscriptions.remove(i);
             }
         }
-        return false;
+        return null;
     }
 
     public synchronized void setMaxInFlight(String topic, String channel, int maxInFlight) {
@@ -190,6 +193,7 @@ public class Subscriber extends BasePubSub {
         for (Subscription subscription : subscriptions) {
             subscription.stop();
         }
+        subscriptions.clear();
         logger.info("subscriber stopped");
     }
 


### PR DESCRIPTION
This implements the proper subscriber connection close procedure. It stops the message flow with the nsqd via the `CLS` command before initiating connection flush and close.

For many subscribers that permanently are subscribed to the same topics, this was never an issue. Subscribers that need to move subscriptions around via subscribe / unsubscribe calls will potentially leak connections everytime a `Subscriber#unsubscribe` call happens.

Tests: Unit, local verification.