### PR TITLE
DP-44: Don't attempt to read the response from nsqd on CLS command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 	mvn verify
 
 deploy:
-	mvn --no-transfer-progress --batch-mode deploy
+	mvn --no-transfer-progress --batch-mode deploy --skipITs=true
 
 docker_teardown:
 	$(SCRIPTS_DIR)/testCleanupDocker.sh

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>1.4.3</version>
+    <version>1.4.4</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/src/main/java/com/sproutsocial/nsq/SubConnection.java
+++ b/src/main/java/com/sproutsocial/nsq/SubConnection.java
@@ -212,9 +212,10 @@ class SubConnection extends Connection {
         try {
             logger.debug("closing conn:{}", this);
             writeCommand("CLS");
-            flushAndReadResponse("CLOSE_WAIT");
         } catch (IOException | NSQException e) {
-            logger.error("error sending nsqd CLS command", e);
+            logger.error("error sending nsqd CLS command. Closing connection immediately.", e);
+            close();
+            return;
         }
 
         if (inFlight == 0) {


### PR DESCRIPTION
The read loop on another thread will read the `CLOSE_WAIT` response from the server, and so our `flushAndReadResponse` call might block waiting for a response for up to ~35 seconds (The default heartbeat connection timeout).

Instead, just fire off the write command, and then have the read loop handle stopping the loop correctly.