### PR TITLE
DP-44: Fixup GH workflow

### DIFF
--- a/.github/workflows/release-and-publish-artifacts.yml
+++ b/.github/workflows/release-and-publish-artifacts.yml
@@ -1,5 +1,6 @@
 name: release and push to central
 on:
+  workflow_dispatch:
   release:
     types:
       - published


### PR DESCRIPTION
We should be able to run the deploy actions manually when we need to, not just on tag / publishing a release.