### PR TITLE
DP-61: Make test teardown operations more null-safe.

### DIFF
--- a/src/test/java/com/sproutsocial/nsq/RoundRobinDockerTestIT.java
+++ b/src/test/java/com/sproutsocial/nsq/RoundRobinDockerTestIT.java
@@ -30,7 +30,9 @@ public class RoundRobinDockerTestIT extends BaseDockerTestIT {
 
     @Override
     public void teardown() throws InterruptedException {
-        subscriber.stop();
+        if (subscriber != null) {
+            subscriber.stop();
+        }
         if (publisher != null) {
             publisher.stop();
         }

--- a/src/test/java/com/sproutsocial/nsq/SubscriberFocusedDockerTestIT.java
+++ b/src/test/java/com/sproutsocial/nsq/SubscriberFocusedDockerTestIT.java
@@ -132,7 +132,9 @@ public class SubscriberFocusedDockerTestIT extends BaseDockerTestIT {
 
     @Override
     public void teardown() throws InterruptedException {
-        publisher.stop();
+        if (publisher != null) {
+            publisher.stop();
+        }
         for (Subscriber subscriber : subscribers) {
             subscriber.stop();
         }


### PR DESCRIPTION
Make these null safe, so we don't blow up teardown operations.