### PR TITLE
Check connection liveness before attempting to publish (dp-58)

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/BalanceStrategy.java
+++ b/src/main/java/com/sproutsocial/nsq/BalanceStrategy.java
@@ -5,7 +5,7 @@ public interface BalanceStrategy {
     /**
      * @throws NSQException When there are no more available connections.  Should be escalated to the user of the library
      */
-    ConnectionDetails getConnectionDetails() throws NSQException;
+    NsqdInstance getNsqdInstance() throws NSQException;
 
     void connectionClosed(PubConnection closedCon);
 

--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -28,7 +28,7 @@ abstract class Connection extends BasePubSub implements Closeable {
 
     protected DataOutputStream out;
     protected DataInputStream in;
-    private volatile boolean isReading = true;
+    protected volatile boolean isReading = true;
 
     protected int msgTimeout = 60000;
     protected int heartbeatInterval = 30000;

--- a/src/main/java/com/sproutsocial/nsq/ListBasedBalanceStrategy.java
+++ b/src/main/java/com/sproutsocial/nsq/ListBasedBalanceStrategy.java
@@ -13,9 +13,9 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 public class ListBasedBalanceStrategy extends BasePubSub implements BalanceStrategy {
     private static final Logger logger = getLogger(ListBasedBalanceStrategy.class);
-    protected final List<ConnectionDetails> daemonList;
+    protected final List<NsqdInstance> daemonList;
     private final Publisher parent;
-    private final Function<List<ConnectionDetails>, ConnectionDetails> connectionDetailsSelector;
+    private final Function<List<NsqdInstance>, NsqdInstance> nsqdInstanceSelector;
     private int failoverDurationSecs = 300;
 
     /**
@@ -46,13 +46,13 @@ public class ListBasedBalanceStrategy extends BasePubSub implements BalanceStrat
     }
 
     private static ListBasedBalanceStrategy buildRoundRobinStrategy(Client client, Publisher parent, List<String> nsqd) {
-        return new ListBasedBalanceStrategy(client, parent, nsqd, new Function<List<ConnectionDetails>, ConnectionDetails>() {
+        return new ListBasedBalanceStrategy(client, parent, nsqd, new Function<List<NsqdInstance>, NsqdInstance>() {
             private int nextDaemonIndex = 0;
 
             @Override
-            public ConnectionDetails apply(List<ConnectionDetails> daemonList) {
+            public NsqdInstance apply(List<NsqdInstance> daemonList) {
                 for (int attempts = 0; attempts < daemonList.size(); attempts++) {
-                    ConnectionDetails candidate = daemonList.get(nextDaemonIndex);
+                    NsqdInstance candidate = daemonList.get(nextDaemonIndex);
                     boolean candidateReady = candidate.makeReady();
                     nextDaemonIndex++;
                     if (nextDaemonIndex >= daemonList.size()) {
@@ -73,7 +73,7 @@ public class ListBasedBalanceStrategy extends BasePubSub implements BalanceStrat
     private static ListBasedBalanceStrategy buildFailoverStrategy(Client client, Publisher parent, List<String> nsqd) {
         return new ListBasedBalanceStrategy(client, parent, nsqd, daemonList -> {
             for (int attempts = 0; attempts < daemonList.size(); attempts++) {
-                ConnectionDetails candidate = daemonList.get(attempts);
+                NsqdInstance candidate = daemonList.get(attempts);
                 if (candidate.makeReady()) {
                     return candidate;
                 }
@@ -85,36 +85,36 @@ public class ListBasedBalanceStrategy extends BasePubSub implements BalanceStrat
         });
     }
 
-    private static void clearAllConnections(final List<ConnectionDetails> daemonList) {
-	for (final ConnectionDetails daemon : daemonList) {
+    private static void clearAllConnections(final List<NsqdInstance> daemonList) {
+	for (final NsqdInstance daemon : daemonList) {
 	    daemon.clearConnection();
 	}
     }
 
-    public ListBasedBalanceStrategy(Client client, Publisher parent, List<String> nsqd, Function<List<ConnectionDetails>, ConnectionDetails> connectionDetailsSelector) {
+    public ListBasedBalanceStrategy(Client client, Publisher parent, List<String> nsqd, Function<List<NsqdInstance>, NsqdInstance> nsqdInstanceSelector) {
         super(client);
         checkNotNull(parent);
         checkNotNull(nsqd);
-        checkNotNull(connectionDetailsSelector);
+        checkNotNull(nsqdInstanceSelector);
 
         this.parent = parent;
-        this.connectionDetailsSelector = connectionDetailsSelector;
-        List<ConnectionDetails> connectionDetails = new ArrayList<>();
+        this.nsqdInstanceSelector = nsqdInstanceSelector;
+        List<NsqdInstance> nsqdInstance = new ArrayList<>();
         for (String host : nsqd) {
             if (host != null)
-                connectionDetails.add(new ConnectionDetails(host, this.parent, this.failoverDurationSecs, this));
+                nsqdInstance.add(new NsqdInstance(host, this.parent, this.failoverDurationSecs, this));
         }
-        daemonList = Collections.unmodifiableList(connectionDetails);
+        daemonList = Collections.unmodifiableList(nsqdInstance);
     }
 
     @Override
-    public ConnectionDetails getConnectionDetails() {
-        return connectionDetailsSelector.apply(daemonList);
+    public NsqdInstance getNsqdInstance() {
+        return nsqdInstanceSelector.apply(daemonList);
     }
 
     @Override
     public synchronized void connectionClosed(PubConnection closedCon) {
-        for (ConnectionDetails daemon : daemonList) {
+        for (NsqdInstance daemon : daemonList) {
             if (daemon.getCon() == closedCon) {
                 daemon.clearConnection();
                 logger.debug("removed closed publisher connection:{}", closedCon.getHost());
@@ -130,8 +130,8 @@ public class ListBasedBalanceStrategy extends BasePubSub implements BalanceStrat
     @Override
     public void setFailoverDurationSecs(int failoverDurationSecs) {
         this.failoverDurationSecs = failoverDurationSecs;
-        for (ConnectionDetails connectionDetails : daemonList) {
-            connectionDetails.setFailoverDurationSecs(failoverDurationSecs);
+        for (NsqdInstance nsqdInstance : daemonList) {
+            nsqdInstance.setFailoverDurationSecs(failoverDurationSecs);
         }
     }
 

--- a/src/main/java/com/sproutsocial/nsq/NsqdInstance.java
+++ b/src/main/java/com/sproutsocial/nsq/NsqdInstance.java
@@ -8,14 +8,14 @@ import java.util.concurrent.TimeUnit;
 import static org.slf4j.LoggerFactory.getLogger;
 import static com.sproutsocial.nsq.Util.*;
 
-class ConnectionDetails {
+class NsqdInstance {
     private enum State {
         CONNECTED,
         NOT_CONNECTED,
         FAILED
     }
 
-    private static final Logger LOGGER = getLogger(ConnectionDetails.class);
+    private static final Logger LOGGER = getLogger(NsqdInstance.class);
     private final Publisher parent;
     private final BasePubSub basePubSub;
     HostAndPort hostAndPort;
@@ -24,7 +24,7 @@ class ConnectionDetails {
     private volatile int failoverDurationSecs;
     private State currentState = State.NOT_CONNECTED;
 
-    public ConnectionDetails(String hostAndPort, Publisher parent, int failoverDurationSecs, BasePubSub basePubSub) {
+    public NsqdInstance(String hostAndPort, Publisher parent, int failoverDurationSecs, BasePubSub basePubSub) {
         checkNotNull(hostAndPort);
         checkNotNull(parent);
         checkNotNull(basePubSub);
@@ -73,7 +73,7 @@ class ConnectionDetails {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        ConnectionDetails that = (ConnectionDetails) o;
+        NsqdInstance that = (NsqdInstance) o;
         return hostAndPort.equals(that.hostAndPort);
     }
 
@@ -106,7 +106,7 @@ class ConnectionDetails {
 
     @Override
     public String toString() {
-        return "ConnectionDetails{" + "parent=" + parent +
+        return "NsqdInstance{" + "parent=" + parent +
                 ", hostAndPort=" + hostAndPort +
                 ", con=" + con +
                 ", failoverStart=" + failoverStart +

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -64,11 +64,11 @@ public class Publisher extends BasePubSub {
         checkNotNull(topic);
         checkNotNull(data);
         checkArgument(data.length > 0);
-        ConnectionDetails connectionDetails = balanceStrategy.getConnectionDetails();
+        NsqdInstance nsqdInstance = balanceStrategy.getNsqdInstance();
         try {
-            connectionDetails.getCon().publish(topic, data);
+            nsqdInstance.getCon().publish(topic, data);
         } catch (Exception e) {
-            connectionDetails.markFailure();
+            nsqdInstance.markFailure();
             logger.error("publish error with", e);
             publish(topic, data);
         }
@@ -84,11 +84,11 @@ public class Publisher extends BasePubSub {
         checkArgument(data.length > 0);
         checkArgument(delay > 0);
         checkNotNull(unit);
-        ConnectionDetails connection = balanceStrategy.getConnectionDetails();
+        NsqdInstance instance = balanceStrategy.getNsqdInstance();
         try {
-            connection.getCon().publishDeferred(topic, data, unit.toMillis(delay));
+            instance.getCon().publishDeferred(topic, data, unit.toMillis(delay));
         } catch (Exception e) {
-            connection.markFailure();
+            instance.markFailure();
             //deferred publish does not retry
             throw new NSQException("deferred publish failed", e);
         }
@@ -104,12 +104,12 @@ public class Publisher extends BasePubSub {
         checkArgument(data.length > 0);
         checkArgument(delay > 0);
         checkNotNull(unit);
-        ConnectionDetails connection = balanceStrategy.getConnectionDetails();
+        NsqdInstance instance = balanceStrategy.getNsqdInstance();
         try {
-            connection.getCon().publishDeferred(topic, data, unit.toMillis(delay));
+            instance.getCon().publishDeferred(topic, data, unit.toMillis(delay));
         } catch (Exception e) {
             logger.error("Deferred publish error", e);
-            connection.markFailure();
+            instance.markFailure();
             publishDeferredWithRetry(topic,data,delay,unit);
         }
     }
@@ -119,12 +119,12 @@ public class Publisher extends BasePubSub {
         checkNotNull(topic);
         checkNotNull(dataList);
         checkArgument(dataList.size() > 0);
-        ConnectionDetails connectionDetails = balanceStrategy.getConnectionDetails();
+        NsqdInstance nsqdInstance = balanceStrategy.getNsqdInstance();
         try {
-            connectionDetails.getCon().publish(topic, dataList);
+            nsqdInstance.getCon().publish(topic, dataList);
         } catch (Exception e) {
             logger.error("publish error", e);
-            connectionDetails.markFailure();
+            nsqdInstance.markFailure();
             // We publish sequentially when we have an MPUB failure to
             // help cover cases where perhaps the total payload size of the
             // MPUB exceeded the nsqd -max-body-size or -max-msg-size.


### PR DESCRIPTION
This PR also renames `ConnectionDetails` -> `NsqdInstance` to more accurately capture what state it tracks