### PR TITLE
Making classes referenced by BalanceStrategy Public

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/NsqdInstance.java
+++ b/src/main/java/com/sproutsocial/nsq/NsqdInstance.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 import static org.slf4j.LoggerFactory.getLogger;
 import static com.sproutsocial.nsq.Util.*;
 
-class NsqdInstance {
+public class NsqdInstance {
     private enum State {
         CONNECTED,
         NOT_CONNECTED,

--- a/src/main/java/com/sproutsocial/nsq/PubConnection.java
+++ b/src/main/java/com/sproutsocial/nsq/PubConnection.java
@@ -3,7 +3,7 @@ package com.sproutsocial.nsq;
 import java.io.IOException;
 import java.util.List;
 
-class PubConnection extends Connection {
+public class PubConnection extends Connection {
 
     private final Publisher publisher;
 


### PR DESCRIPTION
NsqdInstance and PubConnection are referenced in BalanceStrategy interface, but they are not public so the interface cannot be implemented from outside this package - making them Public so that BalanceStrategy can have custom implementations.