### PR TITLE
DP-84: Add lookup method to query the total in-flight message count of all subscriptions.

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/SubConnection.java
+++ b/src/main/java/com/sproutsocial/nsq/SubConnection.java
@@ -231,6 +231,10 @@ class SubConnection extends Connection {
         }
     }
 
+    public synchronized int getCurrentInFlightCount() {
+        return inFlight;
+    }
+
     @Override
     public String toString() {
         return String.format("SubCon:%s %s.%s", host.getHost(), subscription.getTopic(), subscription.getChannel());

--- a/src/main/java/com/sproutsocial/nsq/Subscriber.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscriber.java
@@ -241,6 +241,20 @@ public class Subscriber extends BasePubSub {
         return executor instanceof ThreadPoolExecutor ? ((ThreadPoolExecutor)executor).getQueue().size() : null;
     }
 
+    /**
+     * Return the currently in-flight message count for all active
+     * subscriptions. This count represents the number of messages that
+     * are currently being processed by the the executor service handler
+     * threads.
+     */
+    public synchronized int getCurrentInFlightCount() {
+        int inFlightCount = 0;
+        for (Subscription subscription : subscriptions) {
+            inFlightCount += subscription.getInFlightCount();
+        }
+        return inFlightCount;
+    }
+
     public synchronized int getConnectionCount() {
         int count = 0;
         for (Subscription subscription : subscriptions) {

--- a/src/main/java/com/sproutsocial/nsq/Subscription.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscription.java
@@ -194,4 +194,15 @@ class Subscription extends BasePubSub {
         return connectionMap.size();
     }
 
+    public int getInFlightCount() {
+        int inFlightCount = 0;
+        synchronized (connectionMap) {
+            for (Iterator<SubConnection> iter = connectionMap.values().iterator(); iter.hasNext(); ) {
+                final SubConnection con = iter.next();
+                inFlightCount += con.getCurrentInFlightCount();
+            }
+        }
+        return inFlightCount;
+    }
+
 }


### PR DESCRIPTION
This is useful in order to synchronize tests and make sure there are no currently in-flight messages.