### PR TITLE
LIS-9781: Introduce SubscriptionId for unique subscription identifiers

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Subscription.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscription.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ScheduledFuture;
 import static com.sproutsocial.nsq.Util.copy;
 
 class Subscription extends BasePubSub {
-
+    private final SubscriptionId subscriptionId;
     private final String topic;
     private final String channel;
     private final MessageHandler handler;
@@ -20,13 +20,24 @@ class Subscription extends BasePubSub {
 
     private static final Logger logger = LoggerFactory.getLogger(Subscription.class);
 
-    public Subscription(Client client, String topic, String channel, MessageHandler handler, Subscriber subscriber, int maxInFlight) {
+    public Subscription(final SubscriptionId subscriptionId,
+                        final Client client,
+                        final String topic,
+                        final String channel,
+                        final MessageHandler handler,
+                        final Subscriber subscriber,
+                        final int maxInFlight) {
         super(client);
+        this.subscriptionId = subscriptionId;
         this.topic = topic;
         this.channel = channel;
         this.handler = handler;
         this.subscriber = subscriber;
         this.maxInFlight = maxInFlight;
+    }
+
+    public SubscriptionId getSubscriptionId() {
+        return subscriptionId;
     }
 
     public synchronized int getMaxInFlight() {
@@ -187,7 +198,7 @@ class Subscription extends BasePubSub {
 
     @Override
     public String toString() {
-        return String.format("subscription %s.%s connections:%s", topic, channel, connectionMap.size());
+        return String.format("subscription id %s, %s.%s connections:%s", subscriptionId, topic, channel, connectionMap.size());
     }
 
     public int getConnectionCount() {

--- a/src/main/java/com/sproutsocial/nsq/SubscriptionId.java
+++ b/src/main/java/com/sproutsocial/nsq/SubscriptionId.java
@@ -1,0 +1,38 @@
+package com.sproutsocial.nsq;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Represents a unique subscription that's returned from a call to {@link Subscriber#subscribe}.
+ * Can be passed to methods such as {@link Subscriber#unsubscribe} to remove a subscription.
+ */
+public class SubscriptionId {
+    private final long id;
+
+    protected SubscriptionId(final long id) {
+        this.id = id;
+    }
+
+    static SubscriptionId fromCounter(final AtomicLong counter) {
+        return new SubscriptionId(counter.getAndIncrement());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) { return true; }
+        if (!(other instanceof SubscriptionId)) { return false; }
+        SubscriptionId that = (SubscriptionId)other;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "SubscriptionId { " + id + " }";
+    }
+}


### PR DESCRIPTION
Previously, we introduced the `Subscriber#unsubscribe(String topic, String channel)` call.

This method is unfortunately not correct if we create more than one subscription to the same topic, with the same channel, which is possible with the current client.

We would get in a situation where the unsubscribe call would unsubscribe from whatever subscription was created first.

This change:

1. Changes `Subscriber#subscribe` to return a unique `SubscriptionId` for each subscription. This method previously returned void, so should not be a breaking change.
2. Deprecates the old `Subscriber#unsubscribe(String topic, String channel)` call.
3. Replaces the call with a new `Subscriber#unsubscribe(SubscriptionId)`.

Tests: Unit.