### PR TITLE
Add hasResponded check to Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Add a dependency using Maven
 <dependency>
   <groupId>com.sproutsocial</groupId>
   <artifactId>nsq-j</artifactId>
-  <version>1.4.6</version>
+  <version>1.4.8</version>
 </dependency>
 ```
 or Gradle
 ```
 dependencies {
-  compile 'com.sproutsocial:nsq-j:1.4.6'
+  compile 'com.sproutsocial:nsq-j:1.4.8'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>1.4.7</version>
+    <version>1.4.8</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/src/main/java/com/sproutsocial/nsq/Message.java
+++ b/src/main/java/com/sproutsocial/nsq/Message.java
@@ -22,4 +22,8 @@ public interface Message {
 
     void forceFlush();
 
+    default boolean hasResponded() {
+        return false;
+    }
+
 }

--- a/src/main/java/com/sproutsocial/nsq/NSQMessage.java
+++ b/src/main/java/com/sproutsocial/nsq/NSQMessage.java
@@ -62,7 +62,7 @@ class NSQMessage implements Message {
     @Override
     public void requeue(int delayMillis) {
         if (responded.compareAndSet(false, true)) {
-            connection.requeue(id, delayMillis);;
+            connection.requeue(id, delayMillis);
         }
     }
 

--- a/src/main/java/com/sproutsocial/nsq/NSQMessage.java
+++ b/src/main/java/com/sproutsocial/nsq/NSQMessage.java
@@ -1,6 +1,7 @@
 package com.sproutsocial.nsq;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class NSQMessage implements Message {
 
@@ -10,6 +11,7 @@ class NSQMessage implements Message {
     private final byte[] data;
     private final String topic;
     private final SubConnection connection;
+    private final AtomicBoolean responded = new AtomicBoolean();
 
     NSQMessage(long timestamp, int attempts, String id, byte[] data, String topic, SubConnection connection) {
         this.timestamp = timestamp;
@@ -47,21 +49,28 @@ class NSQMessage implements Message {
 
     @Override
     public void finish() {
-        connection.finish(id);
+        if (responded.compareAndSet(false, true)) {
+            connection.finish(id);
+        }
     }
 
     @Override
     public void requeue() {
-        connection.requeue(id);
+        requeue(0);
     }
 
     @Override
     public void requeue(int delayMillis) {
-        connection.requeue(id, delayMillis);
+        if (responded.compareAndSet(false, true)) {
+            connection.requeue(id, delayMillis);;
+        }
     }
 
     @Override
     public void touch() {
+        if (responded.get()) {
+            return;
+        }
         connection.touch(id);
     }
 
@@ -72,6 +81,11 @@ class NSQMessage implements Message {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public boolean hasResponded() {
+        return responded.get();
     }
 
     SubConnection getConnection() {

--- a/src/test/java/com/sproutsocial/nsq/NSQMessageTest.java
+++ b/src/test/java/com/sproutsocial/nsq/NSQMessageTest.java
@@ -1,0 +1,53 @@
+package com.sproutsocial.nsq;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NSQMessageTest {
+
+    private final SubConnection connection = Mockito.mock(SubConnection.class);
+
+    @Before
+    public void resetTest() {
+        Mockito.reset(connection);
+    }
+
+    @Test
+    public void shouldMarkRespondedOnFinish() {
+        final NSQMessage message = new NSQMessage(0L, 0, "id", null, "topic", connection);
+        assertFalse(message.hasResponded());
+        message.finish();
+        assertTrue(message.hasResponded());
+        Mockito.verify(connection).finish("id");
+        Mockito.verifyNoMoreInteractions(connection);
+    }
+
+    @Test
+    public void shouldMarkRespondedOnRequeue() {
+        final NSQMessage message = new NSQMessage(0L, 0, "id", null, "topic", connection);
+        assertFalse(message.hasResponded());
+        message.requeue();
+        assertTrue(message.hasResponded());
+        Mockito.verify(connection).requeue("id", 0);
+        Mockito.verifyNoMoreInteractions(connection);
+    }
+
+    @Test
+    public void shouldNotTouchWhenResponded() {
+        final NSQMessage message = new NSQMessage(0L, 0, "id", null, "topic", connection);
+        assertFalse(message.hasResponded());
+        message.touch();
+        Mockito.verify(connection).touch("id");
+        message.requeue();
+        assertTrue(message.hasResponded());
+        // reset mock
+        Mockito.reset(connection);
+        message.touch();
+        Mockito.verifyZeroInteractions(connection);
+    }
+
+}


### PR DESCRIPTION
This adds the capability to check if a message has been responded to, by `finish` or `requeue`. It also makes these operations idempotent and NOOP after the first attempt.

In addition to this, it also makes `touch` a NOOP when a message has already been responded to.

Callers can now unconditinally `finish` or `requeue` without being concerned about any acknowledgemnt that has happened before. Or they can simply check if a message has been responded to or not.

For backwards-compatility, the interface method defaults to returning `false`.