### PR TITLE
DP-85: Add Subscriber#drainInFlight, to support graceful in-flight shutdown.

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Subscriber.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscriber.java
@@ -267,6 +267,17 @@ public class Subscriber extends BasePubSub {
     }
 
     /**
+     * Set all active subscriptions and their connections to maxInFlight: 0. It
+     * is still the callers responsibility to use {@link Subscriber#getCurrentInFlightCount}
+     * to verify that there are no in-flight messages before calling {@link Subscriber#stop}
+     */
+    public synchronized void drainInFlight() {
+        for (Subscription subscription : subscriptions) {
+            subscription.setMaxInFlight(0);
+        }
+    }
+
+    /**
      * Return the currently in-flight message count for all active
      * subscriptions. This count represents the number of messages that
      * are currently being processed by the the executor service handler


### PR DESCRIPTION
Adds a new API to set all the active subscriptions to 'maxInFlight: 0'. This is useful during subscriber shutdown to stop the flow of all in-flight messages.

Can also be paired with 'getCurrentInFlightCount' to assert that we have no in-flight messages.

It's possible to eventually incorporate this into a 'drainAndStop' style method that can wrap all the correct stop sequence to ensure the client has nothing in flight.