### PR TITLE
Making the connection nsq-read threads daemon

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -89,11 +89,14 @@ abstract class Connection extends BasePubSub implements Closeable {
         }, heartbeatInterval + 2000, heartbeatInterval, false);
         lastHeartbeat = Util.clock();
 
-        readThreadFactory.newThread(new Runnable() {
+        Thread thread = readThreadFactory.newThread(new Runnable() {
             public void run() {
                 read();
             }
-        }).start();
+        });
+
+        thread.setDaemon(true);
+        thread.start();
     }
 
     private String connectCommand(String command, byte[] data) throws IOException {


### PR DESCRIPTION
I've noticed using the library that there is a dangling non daemon thread that keeps the app open even after closing all the resources created via the library.

I spotted where the dangling thread gets created and I've managed to make it a daemon thread.

This example is a MRE that hungs with the current lib version. This PR fixes this behaviour and correctly closes the application.
```java
import com.sproutsocial.nsq.*;

public class nsq {
  public static void main(String[] args) throws Exception {
    Publisher publisher = new Publisher("localhost:4150");
    Subscriber subscriber = new Subscriber("localhost:4161");
    publisher.publish("example_topic", "Hello nsq".getBytes());
    subscriber.subscribe("example_topic", "paperino", nsq::handleData);
    publisher.stop();
    subscriber.stop();
  }

  public static void handleData(byte[] data) {
    System.out.println("Received:" + new String(data));
  }
}
```