### PR TITLE
TRG-1835: Use Correct Configuration to Check TLS Warning Setting

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -80,7 +80,7 @@ abstract class Connection extends BasePubSub implements Closeable {
             out = new DataOutputStream(new BufferedOutputStream(streams.baseOut));
         }
 
-        sendAuthorization(serverConfig);
+        sendAuthorization(serverConfig, config);
 
         scheduleAtFixedRate(new Runnable() {
             public void run() {
@@ -168,12 +168,12 @@ abstract class Connection extends BasePubSub implements Closeable {
         }
     }
 
-    private void sendAuthorization(ServerConfig serverConfig) throws IOException {
+    private void sendAuthorization(ServerConfig serverConfig, Config config) throws IOException {
         if (serverConfig.getAuthRequired() != null && serverConfig.getAuthRequired()) {
             if (client.getAuthSecret() == null) {
                 throw new NSQException("nsqd requires authorization, call client.setAuthSecret before connecting");
             }
-            if (!serverConfig.getTlsV1() && serverConfig.isWarnWhenNotUsingTls()) {
+            if (!serverConfig.getTlsV1() && config.isWarnWhenNotUsingTls()) {
                 logger.warn("authorization used without encryption. authSecret sent in plain text");
             }
             String authResponse = connectCommand("AUTH", client.getAuthSecret());


### PR DESCRIPTION
This PR fixes a bug in https://github.com/sproutsocial/nsq-j/pull/94 in which the wrong configuration object was used to determine whether or not the following warning should be logged:

```
authorization used without encryption. authSecret sent in plain text
```

`ServerConfig` was erroneously being used, but the setting is provided by `Config`. Because `Config#warnWhenNotUsingTls` defaults to `true`, and because `ServerConfig extends Config`, the setting was unconditionally being evaluated as `true`.

I have manually verified this fix. I started to write a test, but significant refactoring would be required to cleanly mock out the dependencies in the `Connection` class. I did not feel that this change was significant enough to justify the time it would take to do that.

Here is the accompanying release PR: https://github.com/sproutsocial/nsq-j/pull/98

See also:
* https://github.com/sproutsocial/bus/pull/2743
* https://github.com/sproutsocial/configuration-commons/pull/403