### PR TITLE
TRG-1835: Release 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Add a dependency using Maven
 <dependency>
   <groupId>com.sproutsocial</groupId>
   <artifactId>nsq-j</artifactId>
-  <version>1.5.2</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 or Gradle
 ```
 dependencies {
-  compile 'com.sproutsocial:nsq-j:1.5.2'
+  compile 'com.sproutsocial:nsq-j:2.0.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Add a dependency using Maven
 <dependency>
   <groupId>com.sproutsocial</groupId>
   <artifactId>nsq-j</artifactId>
-  <version>2.0.0</version>
+  <version>1.6.0</version>
 </dependency>
 ```
 or Gradle
 ```
 dependencies {
-  compile 'com.sproutsocial:nsq-j:2.0.0'
+  compile 'com.sproutsocial:nsq-j:1.6.0'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>1.5.2</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>nsq-j</artifactId>
-    <version>2.0.0</version>
+    <version>1.6.0</version>
     <packaging>jar</packaging>
 
     <name>nsq-j</name>

--- a/src/main/java/com/sproutsocial/nsq/Config.java
+++ b/src/main/java/com/sproutsocial/nsq/Config.java
@@ -18,7 +18,7 @@ public class Config {
     private Boolean deflate;
     private Integer deflateLevel;
     private Integer sampleRate;
-    private String userAgent = "nsq-j/1.5.2";
+    private String userAgent = "nsq-j/2.0.0";
     private Integer msgTimeout;
 
     private boolean warnWhenNotUsingTls = true;

--- a/src/main/java/com/sproutsocial/nsq/Config.java
+++ b/src/main/java/com/sproutsocial/nsq/Config.java
@@ -18,7 +18,7 @@ public class Config {
     private Boolean deflate;
     private Integer deflateLevel;
     private Integer sampleRate;
-    private String userAgent = "nsq-j/2.0.0";
+    private String userAgent = "nsq-j/1.6.0";
     private Integer msgTimeout;
 
     private boolean warnWhenNotUsingTls = true;


### PR DESCRIPTION
The release PR for https://github.com/sproutsocial/nsq-j/pull/100.

EDIT: After discussion with @erik-helleren, we have determined that this change does not rise to the level a major version bump. ~Although there are no interface changes to any public classes, I am bumping the major version of this library to signal to anyone outside of Sprout who may, for some reason, be relying on the config in the `BalanceStrategy` classes, that this update will break their configuration.~