### PR TITLE
TRG-1835: Use Correct Configuration to Check TLS Warning Setting During Publishing

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/SingleNsqdBalanceStrategy.java
+++ b/src/main/java/com/sproutsocial/nsq/SingleNsqdBalanceStrategy.java
@@ -22,10 +22,7 @@ public class SingleNsqdBalanceStrategy extends BasePubSub implements BalanceStra
                 "This may appear to be lock starvation. " +
                 "The client is also not resilient to failures in this mode, a single outage can result in dataloss and crashing (slowly).  "+
                 "Please use failover or round robin balance strategy to avoid these issues");
-        nsqdInstance = new NsqdInstance(nsqd,
-                parent,
-                this.failoverDurationSecs,
-                this);
+        this.nsqdInstance = new NsqdInstance(client, nsqd, parent, failoverDurationSecs);
     }
 
     @Override

--- a/src/test/java/com/sproutsocial/nsq/RoundRobinDockerTestIT.java
+++ b/src/test/java/com/sproutsocial/nsq/RoundRobinDockerTestIT.java
@@ -92,7 +92,7 @@ public class RoundRobinDockerTestIT extends BaseDockerTestIT {
     }
 
 
-    @Test()
+    @Test
     public void test_allNodesDown_LaterRecovers() {
         publishAndValidateRoundRobinForNodes(cluster.getNsqdNodes(), 0);
 
@@ -123,7 +123,7 @@ public class RoundRobinDockerTestIT extends BaseDockerTestIT {
     }
 
 
-    @Test()
+    @Test
     public void test_twoNodesDown_LaterRecovers() {
         publishAndValidateRoundRobinForNodes(cluster.getNsqdNodes(), 0);
 
@@ -143,11 +143,14 @@ public class RoundRobinDockerTestIT extends BaseDockerTestIT {
     }
 
     @Test
-    public void test_oneNodeDown_FirstPublishDeferredThrowsException() {
+    public void test_oneNodeDown_messageStillPublished() {
         publishAndValidateRoundRobinForNodes(cluster.getNsqdNodes(),0);
         cluster.disconnectNetworkFor(cluster.getNsqdNodes().get(0));
         List<String> messages = messages(1, 20);
-        Assert.assertThrows(NSQException.class, () -> publisher.publishDeferred(topic, messages.get(0).getBytes(), 10, TimeUnit.MILLISECONDS));
+        publisher.publishDeferred(topic, messages.get(0).getBytes(), 10, TimeUnit.MILLISECONDS);
+
+        List<NSQMessage> nsqMessages = handler.drainMessagesOrTimeOut(1);
+        assertEquals(messages.get(0), new String(nsqMessages.get(0).getData()));
     }
 
     @Test


### PR DESCRIPTION
https://github.com/sproutsocial/nsq-j/pull/97 fixed a bug in which the wrong `Config` instance was being used to determine whether or not the following warning should be logged:

https://github.com/sproutsocial/nsq-j/blob/7f890372d1e198dce1b5a9cb5ae4786e2a230c0c/src/main/java/com/sproutsocial/nsq/Connection.java#L177

However, the fix only applied to subscribers because publishers use yet _another_ wrong instance of `Config`.

This PR:
1. Updates `NsqdInstance` to use the `Config` instance held by `Publisher` ([which is the correct instance](https://github.com/sproutsocial/configuration-commons/blob/90cb4495c0e96ab9ba870aa744139acc7a83f5fd/configuration-commons-bus/src/main/java/com/sproutsocial/configuration/bus/BusFactory.java#L515), at least internally) when initializing a connection.
2. Replaces the `basePubSub` field in `NsqdInstance` with `Client` because that is all that `NsqdInstance` needs from `basePubSub` after the change described in the previous point. This cuts out the middleman.
3. Updates `RoundRobinDockerTestIT#test_oneNodeDown_FirstPublishDeferredThrowsException`, which is unrelated, but has been failing consistently in CI.

I have manually verified this fix.

EDIT: After discussion with @erik-helleren, we have determined that this change does not rise to the level a major version bump. ~Although there are no interface changes to any `public` classes, I am bumping the major version of this library to signal to anyone outside of Sprout who may, for some reason, be relying on the config in the `BalanceStrategy` classes, that this update will break their configuration.~

A better approach would be to centralize `Config` so that it is only set and obtained from a single location. Unfortunately, I foresee that being quite a bit of work, as well as necessitating interface changes which would be very annoying within Sprout.

Here is the accompanying release PR: https://github.com/sproutsocial/nsq-j/pull/99