### PR TITLE
TRG-1861: Update Workflows to Limit GitHub Token Scope

### DIFF
--- a/.github/workflows/release-and-publish-artifacts.yml
+++ b/.github/workflows/release-and-publish-artifacts.yml
@@ -1,4 +1,6 @@
 name: release and push to central
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   release:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,4 +1,6 @@
 name: execute test suite
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
CodeQL suggested limiting the scope of `GITHUB_TOKEN` for the two workflows in this repository:
1. https://github.com/sproutsocial/nsq-j/security/code-scanning/1
1. https://github.com/sproutsocial/nsq-j/security/code-scanning/2

This PR implements the recommendations made in the links above. As far as I can tell, the workflows only read the contents of the repository, so the `contents:read` scope should be sufficient.

I will cut [release 1.6.1](https://github.com/sproutsocial/nsq-j/pull/102) after merging this ticket so that we can verify this change to the workflows.