### PR TITLE
UMS-1007: Clear the interrupted flag while iterating and checking host connections.

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Subscription.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscription.java
@@ -72,10 +72,10 @@ class Subscription extends BasePubSub {
                     connectionMap.put(activeHost, con);
                 }
                 catch (Exception e) {
+                    logger.error("error connecting to:{}, interrupted:{}", activeHost, Thread.interrupted(), e);
                     if(con != null) {
                         con.close();
                     }
-                    logger.error("error connecting to:{}", activeHost, e);
                 }
             }
         }


### PR DESCRIPTION
Because we're not clearing the Thread.interrupted flag while iterating hosts, any single host that gets interrupted waiting for a response will cascade to all of them getting interrupted.

Here's Connection#flushAndReadResponse where one of the many connections underneath the subscription might get interrupted:

```java
    protected void flushAndReadResponse(final String expectedResponse) throws IOException {
        flush();
        try {
            String resp = respQueue.poll(heartbeatInterval, TimeUnit.MILLISECONDS);
            if (!expectedResponse.equals(resp)) {
                throw new NSQException("bad response:" + (resp != null ? resp : "timeout"));
            }
        }
        catch (InterruptedException e) {
            Thread.currentThread().interrupt();
            throw new NSQException("read interrupted");
        }
    }
```

In production, with high counts of nsqd instances, we could be iterating 10's to hundreds of individual nsqd nodes.

This means that any host that actually *is* healthy (after the first gets interrupted) will get all the way through handshake, authentication, identify, and a SUB call, but then immediately throw an InterruptedException  when blocking waiting for an OK TCP response from the server.

This will result in a pile-up of connections. The way the subscription closes connections during cleanup just cuts the TCP connection, rather than going through proper CLS shutdown, which during network instability might cause TCP connection issues with the nsqd node.

Simple fix: Check and clear the Thread.interrupted when we throw an exception during connection checking to prevent follow-on host connections from getting interrupted.

Relevant stacktrace we see during failure:

```
com.sproutsocial.nsq.NSQException: read interrupted
	at com.sproutsocial.nsq.Connection.flushAndReadResponse(Connection.java:331)
	at com.sproutsocial.nsq.Connection.flushAndReadOK(Connection.java:318)
	at com.sproutsocial.nsq.SubConnection.connect(SubConnection.java:155)
	at com.sproutsocial.nsq.Subscription.checkConnections(Subscription.java:71)
	at com.sproutsocial.nsq.Subscriber.subscribe(Subscriber.java:101)
	at com.sproutsocial.nsq.Subscriber.subscribe(Subscriber.java:71)
	at com.sproutsocial.nsqjournal.cluster.WorkerShard.assignTopicPartition(WorkerShard.java:63)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at com.sproutsocial.nsqjournal.cluster.WorkerShard.assignTopicPartitions(WorkerShard.java:45)
	at com.sproutsocial.nsqjournal.cluster.WorkerShard.start(WorkerShard.java:95)
	at com.sproutsocial.nsqjournal.roles.Worker.lambda$asyncStartShard$2(Worker.java:424)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```