### PR TITLE
[AUTOTEST-387] Handle SocketTimeoutException at WARN level in read thread

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -10,6 +10,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -271,6 +272,12 @@ abstract class Connection extends BasePubSub implements Closeable {
                 else if (response != null) {
                     respQueue.offer(response);
                 }
+            }
+        }
+        catch (SocketTimeoutException e) {
+            if (isReading) {
+                logger.warn("read thread socket timeout. con:{}", toString());
+                close();
             }
         }
         catch (EOFException e) {


### PR DESCRIPTION
The nsq-j library's `Connection.read()` method catches all exceptions — including `SocketTimeoutException` — in a generic `catch (Exception e)` block that logs at ERROR level. This triggers unnecessary Sentry alerts in consuming services (e.g., everyday-poller) for what is actually a recoverable, transient condition: the connection auto-reconnects on the next lookup cycle. This change adds a dedicated catch block for `SocketTimeoutException` that logs at WARN level, matching the existing `EOFException` handler pattern.

## Change Summary

- **`src/main/java/com/sproutsocial/nsq/Connection.java`**: Added `import java.net.SocketTimeoutException` (line 13). Added a new `catch (SocketTimeoutException e)` block before the existing `EOFException` catch in the `read()` method (lines 277–282). The new handler checks the `isReading` guard, logs at WARN level with `"read thread socket timeout. con:{}"`, and calls `close()` to trigger reconnection — exactly mirroring the `EOFException` handler structure. The generic `catch (Exception e)` block remains unchanged for unexpected exceptions.

## Related Links

- [AUTOTEST-387](https://sprout.atlassian.net/browse/AUTOTEST-387)
- [worker run #25530227688](https://github.com/sproutsocial/coding-agents/actions/runs/25530227688)
- [Sentry: EVERYDAY-POLLER-75G: SocketTimeoutException: Read timed out](https://sprout-social.sentry.io/issues/7466783105/?referrer=jira_integration)


[AUTOTEST-387]: https://sprout.atlassian.net/browse/AUTOTEST-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ