### PR TITLE
[Claude] [AUTOTEST-446] Make lookupTopic timeout configurable and fix connection leak

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Subscriber.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscriber.java
@@ -34,6 +34,7 @@ public class Subscriber extends BasePubSub {
     private final AtomicLong subscriptionIdCounter = new AtomicLong(0L);
     private final int lookupIntervalSecs;
     private int maxLookupFailuresBeforeError;
+    private int lookupTimeoutMillis = DEFAULT_LOOKUP_TIMEOUT_MILLIS;
     private int defaultMaxInFlight = 200;
     private int maxFlushDelayMillis = 2000;
     private int maxAttempts = Integer.MAX_VALUE;
@@ -42,6 +43,7 @@ public class Subscriber extends BasePubSub {
 
     private static final int DEFAULT_LOOKUP_INTERVAL_SECS = 60;
     private static final int DEFAULT_MAX_LOOKUP_FAILURES_BEFORE_ERROR = 5;
+    private static final int DEFAULT_LOOKUP_TIMEOUT_MILLIS = 30000;
 
     private static final Logger logger = LoggerFactory.getLogger(Subscriber.class);
 
@@ -168,15 +170,15 @@ public class Subscriber extends BasePubSub {
         for (HostAndPort lookup : lookups) {
             String urlString = null;
             BufferedReader in = null;
+            HttpURLConnection con = null;
             try {
                 urlString = String.format("http://%s/lookup?topic=%s", lookup, URLEncoder.encode(topic, "UTF-8"));
                 URL url = new URL(urlString);
-                HttpURLConnection con = (HttpURLConnection) url.openConnection();
-                con.setConnectTimeout(30000);
-                con.setReadTimeout(30000);
+                con = (HttpURLConnection) url.openConnection();
+                con.setConnectTimeout(lookupTimeoutMillis);
+                con.setReadTimeout(lookupTimeoutMillis);
                 if (con.getResponseCode() != 200) {
                     logger.debug("ignoring lookup resp:{} nsqlookupd:{} topic:{}", con.getResponseCode(), lookup, topic);
-                    con.disconnect();
                     continue;
                 }
                 in = new BufferedReader(new InputStreamReader(con.getInputStream()));
@@ -210,6 +212,9 @@ public class Subscriber extends BasePubSub {
             }
             finally {
                 Util.closeQuietly(in);
+                if (con != null) {
+                    con.disconnect();
+                }
             }
         }
         return nsqds;
@@ -262,6 +267,15 @@ public class Subscriber extends BasePubSub {
 
     public synchronized int getLookupIntervalSecs() {
         return lookupIntervalSecs;
+    }
+
+    public synchronized int getLookupTimeoutMillis() {
+        return lookupTimeoutMillis;
+    }
+
+    public synchronized void setLookupTimeoutMillis(int lookupTimeoutMillis) {
+        checkArgument(lookupTimeoutMillis > 0);
+        this.lookupTimeoutMillis = lookupTimeoutMillis;
     }
 
     public Integer getExecutorQueueSize() {

--- a/src/test/java/com/sproutsocial/nsq/SubscriberTest.java
+++ b/src/test/java/com/sproutsocial/nsq/SubscriberTest.java
@@ -1,0 +1,33 @@
+package com.sproutsocial.nsq;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SubscriberTest {
+
+    @Test
+    public void lookupTimeoutMillisDefaultsTo30000() {
+        Subscriber subscriber = new Subscriber("localhost:4161");
+        assertEquals(30000, subscriber.getLookupTimeoutMillis());
+    }
+
+    @Test
+    public void setLookupTimeoutMillisUpdatesValue() {
+        Subscriber subscriber = new Subscriber("localhost:4161");
+        subscriber.setLookupTimeoutMillis(5000);
+        assertEquals(5000, subscriber.getLookupTimeoutMillis());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setLookupTimeoutMillisRejectsZero() {
+        Subscriber subscriber = new Subscriber("localhost:4161");
+        subscriber.setLookupTimeoutMillis(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setLookupTimeoutMillisRejectsNegative() {
+        Subscriber subscriber = new Subscriber("localhost:4161");
+        subscriber.setLookupTimeoutMillis(-1);
+    }
+}


### PR DESCRIPTION
The `lookupTopic()` method in `Subscriber.java` hardcodes HTTP connect and read timeouts to 30 seconds when querying nsqlookupd. When nsqlookupd is unreachable, this causes threads to block for 30s per host — far too long for what should be a millisecond-level lookup. Additionally, the `HttpURLConnection` was never disconnected on the exception path (e.g. `SocketTimeoutException`), leaking resources. This change makes the timeout configurable via a setter and ensures proper connection cleanup in all code paths.

## Change Summary

- **`src/main/java/com/sproutsocial/nsq/Subscriber.java`**: Added `DEFAULT_LOOKUP_TIMEOUT_MILLIS` constant (30000) and `lookupTimeoutMillis` instance field. In `lookupTopic()`, replaced hardcoded `30000` in `setConnectTimeout()`/`setReadTimeout()` with the configurable field. Moved `HttpURLConnection con` declaration outside the try block and added `con.disconnect()` in the finally block (with null guard) to ensure cleanup on all paths, including `SocketTimeoutException`. Removed the now-redundant `con.disconnect()` from the non-200 response branch since the finally block handles it. Added synchronized `getLookupTimeoutMillis()` and `setLookupTimeoutMillis(int)` methods following the existing setter pattern (e.g. `setMaxFlushDelayMillis`), with `checkArgument(timeout > 0)` validation.

- **`src/test/java/com/sproutsocial/nsq/SubscriberTest.java`** (new): Unit tests verifying the default timeout is 30000ms, that `setLookupTimeoutMillis()` updates the value, and that zero/negative values are rejected with `IllegalArgumentException`.

## Related Links

- [AUTOTEST-446](https://sprout.atlassian.net/browse/AUTOTEST-446)
- [worker run #25962899805](https://github.com/sproutsocial/coding-agents/actions/runs/25962899805)
- [Sentry: SocketTimeoutException: Connect timed out](https://sprout-social.sentry.io/issues/7485237483/?referrer=jira_integration)


[AUTOTEST-446]: https://sprout.atlassian.net/browse/AUTOTEST-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ