### PR TITLE
[Claude] [AUTOTEST-449] Fix continuous ERROR logging after lookup failure threshold

### DIFF
--- a/src/main/java/com/sproutsocial/nsq/Subscriber.java
+++ b/src/main/java/com/sproutsocial/nsq/Subscriber.java
@@ -200,7 +200,7 @@ public class Subscriber extends BasePubSub {
                 lookupFailureCount++;
                 this.failures.put(urlString, lookupFailureCount);
 
-                if (lookupFailureCount >= this.maxLookupFailuresBeforeError) {
+                if (lookupFailureCount == this.maxLookupFailuresBeforeError) {
                     logger.error("lookup failure. lookup failed for {} consecutive tries. nsqlookupd:{} topic:{}",
                             lookupFailureCount, lookup, topic, e);
                 } else {

--- a/src/test/java/com/sproutsocial/nsq/SubscriberLookupFailureTest.java
+++ b/src/test/java/com/sproutsocial/nsq/SubscriberLookupFailureTest.java
@@ -1,0 +1,93 @@
+package com.sproutsocial.nsq;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class SubscriberLookupFailureTest {
+
+    private static final int MAX_FAILURES_BEFORE_ERROR = 3;
+    private static final String UNREACHABLE_HOST = "127.0.0.1:1";
+
+    private Subscriber subscriber;
+    private ListAppender<ILoggingEvent> logAppender;
+    private Logger subscriberLogger;
+
+    @Before
+    public void setUp() {
+        subscriber = new Subscriber(Client.getDefaultClient(), 60, MAX_FAILURES_BEFORE_ERROR, UNREACHABLE_HOST);
+
+        subscriberLogger = (Logger) LoggerFactory.getLogger(Subscriber.class);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        subscriberLogger.addAppender(logAppender);
+    }
+
+    @After
+    public void tearDown() {
+        subscriberLogger.detachAppender(logAppender);
+        subscriber.stop();
+    }
+
+    @Test
+    public void errorLoggedExactlyOnceAtThreshold() {
+        int totalCalls = 6;
+        for (int i = 0; i < totalCalls; i++) {
+            subscriber.lookupTopic("test-topic");
+        }
+
+        List<ILoggingEvent> lookupEvents = logAppender.list.stream()
+                .filter(e -> e.getMessage().contains("lookup failure"))
+                .collect(Collectors.toList());
+
+        assertEquals(totalCalls, lookupEvents.size());
+
+        long errorCount = lookupEvents.stream().filter(e -> e.getLevel() == Level.ERROR).count();
+        long warnCount = lookupEvents.stream().filter(e -> e.getLevel() == Level.WARN).count();
+
+        assertEquals("ERROR should be logged exactly once at the threshold", 1, errorCount);
+        assertEquals("All other failures should be WARN", totalCalls - 1, warnCount);
+
+        assertEquals(Level.WARN, lookupEvents.get(0).getLevel());
+        assertEquals(Level.WARN, lookupEvents.get(1).getLevel());
+        assertEquals(Level.ERROR, lookupEvents.get(2).getLevel());
+        assertEquals(Level.WARN, lookupEvents.get(3).getLevel());
+        assertEquals(Level.WARN, lookupEvents.get(4).getLevel());
+        assertEquals(Level.WARN, lookupEvents.get(5).getLevel());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void errorRelogsAfterRecoveryAndReFailure() throws Exception {
+        for (int i = 0; i < MAX_FAILURES_BEFORE_ERROR; i++) {
+            subscriber.lookupTopic("test-topic");
+        }
+
+        Field failuresField = Subscriber.class.getDeclaredField("failures");
+        failuresField.setAccessible(true);
+        ((Map<String, Integer>) failuresField.get(subscriber)).clear();
+
+        for (int i = 0; i < MAX_FAILURES_BEFORE_ERROR; i++) {
+            subscriber.lookupTopic("test-topic");
+        }
+
+        List<ILoggingEvent> lookupEvents = logAppender.list.stream()
+                .filter(e -> e.getMessage().contains("lookup failure"))
+                .collect(Collectors.toList());
+
+        long errorCount = lookupEvents.stream().filter(e -> e.getLevel() == Level.ERROR).count();
+        assertEquals("ERROR should be logged once per threshold crossing", 2, errorCount);
+    }
+}


### PR DESCRIPTION
The Airlock service generates hundreds of Sentry alerts per hour during routine nsqlookupd outages because `Subscriber.lookupTopic()` uses `>=` to compare the lookup failure count against the threshold, causing every failure after the threshold to log at ERROR level indefinitely. This change switches the comparison to `==` so ERROR is emitted exactly once when the threshold is first reached, with all subsequent failures logged at WARN. The subscriber's resilience behavior is unchanged — it continues retrying and resets the counter on recovery.

## Change Summary

- **`src/main/java/com/sproutsocial/nsq/Subscriber.java`**: Changed the condition at line 203 in `lookupTopic()` from `lookupFailureCount >= this.maxLookupFailuresBeforeError` to `lookupFailureCount == this.maxLookupFailuresBeforeError`. This ensures ERROR is logged only once when the failure count first reaches the threshold (default: 5), and all subsequent consecutive failures continue at WARN level. The failure counter reset on success (line 190) is unchanged, so a new ERROR will still be logged if the host recovers and then fails again.

- **`src/test/java/com/sproutsocial/nsq/SubscriberLookupFailureTest.java`** (new): JUnit 4 unit test that verifies the log level escalation behavior. `errorLoggedExactlyOnceAtThreshold` asserts that across 6 consecutive lookup failures with a threshold of 3, exactly 1 is logged at ERROR (the 3rd) and the remaining 5 at WARN. `errorRelogsAfterRecoveryAndReFailure` verifies that clearing the failure map (simulating recovery) allows a second ERROR to be logged when the threshold is reached again.

## Related Links

- [AUTOTEST-449](https://sprout.atlassian.net/browse/AUTOTEST-449)
- [worker run #25962987363](https://github.com/sproutsocial/coding-agents/actions/runs/25962987363)
- [Sentry: AIRLOCK-1N1: ConnectException: Connection refused in Subscriber.lookupTopic](https://sprout-social.sentry.io/issues/7485242809/?referrer=jira_integration)


[AUTOTEST-449]: https://sprout.atlassian.net/browse/AUTOTEST-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ