### PR TITLE
[TOOLCM-4267] [Claude] chore: upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/release-and-publish-artifacts.yml
+++ b/.github/workflows/release-and-publish-artifacts.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release-env
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup build dependencies
         run: make setup
       - name: Set up Java for publishing to Maven Central Repository

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: release-env
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup build dependencies
         run: make setup
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions workflow files to Node.js 24 compatible versions ahead of GitHub's **June 2, 2026** enforcement deadline.

Jira: https://sprout.atlassian.net/browse/TOOLCM-4267

## Test plan
- [ ] CI passes on this branch

Your team can merge this at any time — no input needed from me.

🤖 Generated with Claude Code for TOOLCM-4267