### PR TITLE
DATAINJ-5822 Fix nsq-j incident issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 *.iml
 *.pyc
 dependency-reduced-pom.xml
+# CocoIndex Code (ccc)
+/.cocoindex_code/

--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -21,6 +21,8 @@ import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 
 import static com.sproutsocial.nsq.Util.firstNonNull;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 abstract class Connection extends BasePubSub implements Closeable {
 
@@ -59,9 +61,9 @@ abstract class Connection extends BasePubSub implements Closeable {
         sock.setSoTimeout(30000);
         sock.connect(new InetSocketAddress(host.getHost(), host.getPort()), 30000);
         StreamPair streams = setStreams(sock.getInputStream(), sock.getOutputStream(), new StreamPair());
-        out.write("  V2".getBytes(Util.US_ASCII));
+        out.write("  V2".getBytes(US_ASCII));
 
-        String response = connectCommand("IDENTIFY", client.getGson().toJson(config).getBytes(Util.UTF_8));
+        String response = connectCommand("IDENTIFY", client.getGson().toJson(config).getBytes(UTF_8));
         ServerConfig serverConfig = client.getGson().fromJson(response, ServerConfig.class);
         logger.debug("serverConfig:{}", response);
         setConfig(serverConfig);
@@ -97,7 +99,7 @@ abstract class Connection extends BasePubSub implements Closeable {
     }
 
     private String connectCommand(String command, byte[] data) throws IOException {
-        out.write((command + "\n").getBytes(Util.US_ASCII));
+        out.write((command + "\n").getBytes(US_ASCII));
         write(data);
         out.flush();
         return readResponse();
@@ -201,17 +203,17 @@ abstract class Connection extends BasePubSub implements Closeable {
 
     @GuardedBy("this")
     protected void writeCommand(String cmd, Object param1, Object param2) throws IOException {
-        out.write((cmd + " " + param1 + " " + param2 + "\n").getBytes(Util.US_ASCII));
+        out.write((cmd + " " + param1 + " " + param2 + "\n").getBytes(US_ASCII));
     }
 
     @GuardedBy("this")
     protected void writeCommand(String cmd, Object param) throws IOException {
-        out.write((cmd + " " +  param + "\n").getBytes(Util.US_ASCII));
+        out.write((cmd + " " +  param + "\n").getBytes(US_ASCII));
     }
 
     @GuardedBy("this")
     protected void writeCommand(String cmd) throws IOException {
-        out.write((cmd + "\n").getBytes(Util.US_ASCII));
+        out.write((cmd + "\n").getBytes(US_ASCII));
     }
 
     @GuardedBy("this")
@@ -291,7 +293,7 @@ abstract class Connection extends BasePubSub implements Closeable {
 
     private synchronized void receivedHeartbeat() {
         try {
-            out.write("NOP\n".getBytes(Util.US_ASCII));
+            out.write("NOP\n".getBytes(US_ASCII));
             out.flush(); //NOP does not update lastActionFlush
             lastHeartbeat = Util.clock();
         }
@@ -311,7 +313,7 @@ abstract class Connection extends BasePubSub implements Closeable {
     }
 
     private String readAscii(int size) throws IOException {
-        return new String(readBytes(size), Util.US_ASCII);
+        return new String(readBytes(size), US_ASCII);
     }
 
     protected void flushAndReadOK() throws IOException {

--- a/src/main/java/com/sproutsocial/nsq/Connection.java
+++ b/src/main/java/com/sproutsocial/nsq/Connection.java
@@ -328,7 +328,7 @@ abstract class Connection extends BasePubSub implements Closeable {
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new NSQException("read interrupted");
+            throw new NSQInterruptedException("read interrupted", e);
         }
     }
 

--- a/src/main/java/com/sproutsocial/nsq/ListBasedBalanceStrategy.java
+++ b/src/main/java/com/sproutsocial/nsq/ListBasedBalanceStrategy.java
@@ -62,8 +62,9 @@ public class ListBasedBalanceStrategy extends BasePubSub implements BalanceStrat
                         return candidate;
                     }
                 }
-                // We've gotten to the point where all connections have been marked as 'failed'. Rather than intentionally
-                // dropping messages on the floor, let's at least attempt to reconnect for subsequent message publishing.
+                // All hosts are in FAILED state and none have exceeded the failover backoff yet.
+                // Emit an error log and enforce the backoff — reconnection will be attempted naturally
+                // once failoverDurationSecs elapses.
                 clearAllConnections(daemonList);
                 throw new NSQException("publish failed: Unable to establish a connection with any NSQ host: " + daemonList);
             }
@@ -78,16 +79,18 @@ public class ListBasedBalanceStrategy extends BasePubSub implements BalanceStrat
                     return candidate;
                 }
             }
-            // We've gotten to the point where all connections have been marked as 'failed'. Rather than intentionally
-            // dropping messages on the floor, let's at least attempt to reconnect for subsequent message publishing.
+            // All hosts are in FAILED state and none have exceeded the failover backoff yet.
+            // Emit an error log and enforce the backoff — reconnection will be attempted naturally
+            // once failoverDurationSecs elapses.
             clearAllConnections(daemonList);
             throw new NSQException("publish failed: Unable to establish a connection with any NSQ host: " + daemonList);
         });
     }
 
     private static void clearAllConnections(final List<NsqdInstance> daemonList) {
+        logger.error("All NSQ hosts exhausted; failover backoff enforced for all hosts. hosts={}", daemonList);
         for (final NsqdInstance daemon : daemonList) {
-            daemon.clearConnection();
+            daemon.markFailureIfNotAlready();
         }
     }
 

--- a/src/main/java/com/sproutsocial/nsq/NSQInterruptedException.java
+++ b/src/main/java/com/sproutsocial/nsq/NSQInterruptedException.java
@@ -1,0 +1,11 @@
+package com.sproutsocial.nsq;
+
+public class NSQInterruptedException extends NSQException {
+    public NSQInterruptedException(String message) {
+        super(message);
+    }
+
+    public NSQInterruptedException(String message, InterruptedException cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/sproutsocial/nsq/NSQInterruptedException.java
+++ b/src/main/java/com/sproutsocial/nsq/NSQInterruptedException.java
@@ -5,7 +5,7 @@ public class NSQInterruptedException extends NSQException {
         super(message);
     }
 
-    public NSQInterruptedException(String message, InterruptedException cause) {
+    public NSQInterruptedException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/com/sproutsocial/nsq/NsqdInstance.java
+++ b/src/main/java/com/sproutsocial/nsq/NsqdInstance.java
@@ -62,6 +62,9 @@ class NsqdInstance {
             con.connect(parent.getConfig());
             currentState = State.CONNECTED;
         } catch (IOException e) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new NSQInterruptedException("connect interrupted");
+            }
             markFailure();
             return false;
         }
@@ -90,6 +93,13 @@ class NsqdInstance {
         LOGGER.warn("Marking the connection to host {} as failed , will retry after {} seconds", hostAndPort, this.failoverDurationSecs);
     }
 
+    synchronized void markFailureIfNotAlready() {
+        if (currentState != State.FAILED) {
+            markFailure();
+        }
+        // if already FAILED, preserve existing failoverStart so the timer can expire naturally
+    }
+
     public void setFailoverDurationSecs(int failoverDurationSecs) {
         this.failoverDurationSecs = failoverDurationSecs;
     }
@@ -100,6 +110,7 @@ class NsqdInstance {
     }
 
     public void clearConnection() {
+        Util.closeQuietly(con);
         this.con = null;
         currentState = State.NOT_CONNECTED;
     }

--- a/src/main/java/com/sproutsocial/nsq/NsqdInstance.java
+++ b/src/main/java/com/sproutsocial/nsq/NsqdInstance.java
@@ -19,7 +19,7 @@ class NsqdInstance {
     private final Client client;
     private final Publisher parent;
     HostAndPort hostAndPort;
-    private PubConnection con = null;
+    PubConnection con = null;
     long failoverStart = 0;
     private volatile int failoverDurationSecs;
     private State currentState = State.NOT_CONNECTED;
@@ -63,7 +63,7 @@ class NsqdInstance {
             currentState = State.CONNECTED;
         } catch (IOException e) {
             if (Thread.currentThread().isInterrupted()) {
-                throw new NSQInterruptedException("connect interrupted");
+                throw new NSQInterruptedException("connect interrupted", e);
             }
             markFailure();
             return false;

--- a/src/main/java/com/sproutsocial/nsq/Publisher.java
+++ b/src/main/java/com/sproutsocial/nsq/Publisher.java
@@ -67,6 +67,8 @@ public class Publisher extends BasePubSub {
         NsqdInstance nsqdInstance = balanceStrategy.getNsqdInstance();
         try {
             nsqdInstance.getCon().publish(topic, data);
+        } catch (NSQInterruptedException e) {
+            throw e;
         } catch (Exception e) {
             nsqdInstance.markFailure();
             logger.error("publish error with", e);
@@ -87,6 +89,8 @@ public class Publisher extends BasePubSub {
         NsqdInstance instance = balanceStrategy.getNsqdInstance();
         try {
             instance.getCon().publishDeferred(topic, data, unit.toMillis(delay));
+        } catch (NSQInterruptedException e) {
+            throw e;
         } catch (Exception e) {
             instance.markFailure();
             //deferred publish does not retry
@@ -107,6 +111,8 @@ public class Publisher extends BasePubSub {
         NsqdInstance instance = balanceStrategy.getNsqdInstance();
         try {
             instance.getCon().publishDeferred(topic, data, unit.toMillis(delay));
+        } catch (NSQInterruptedException e) {
+            throw e;
         } catch (Exception e) {
             logger.error("Deferred publish error", e);
             instance.markFailure();
@@ -122,6 +128,8 @@ public class Publisher extends BasePubSub {
         NsqdInstance nsqdInstance = balanceStrategy.getNsqdInstance();
         try {
             nsqdInstance.getCon().publish(topic, dataList);
+        } catch (NSQInterruptedException e) {
+            throw e;
         } catch (Exception e) {
             logger.error("publish error", e);
             nsqdInstance.markFailure();

--- a/src/main/java/com/sproutsocial/nsq/Util.java
+++ b/src/main/java/com/sproutsocial/nsq/Util.java
@@ -5,12 +5,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
@@ -19,9 +18,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 class Util {
-
-    public static final Charset US_ASCII = StandardCharsets.US_ASCII;
-    public static final Charset UTF_8 = StandardCharsets.UTF_8;
 
     private static final Logger logger = LoggerFactory.getLogger(Util.class);
 
@@ -122,7 +118,7 @@ class Util {
     }
 
     public static boolean equal(Object a, Object b) {
-        return a == b || (a != null && a.equals(b));
+        return Objects.equals(a, b);
     }
 
     public static int hashCode(Object... objects) {

--- a/src/main/java/com/sproutsocial/nsq/Util.java
+++ b/src/main/java/com/sproutsocial/nsq/Util.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,27 +20,19 @@ import java.util.concurrent.atomic.AtomicLong;
 
 class Util {
 
-    public static final Charset US_ASCII = Charset.forName("US-ASCII");
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset US_ASCII = StandardCharsets.US_ASCII;
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
 
     private static final Logger logger = LoggerFactory.getLogger(Util.class);
 
     public static ThreadFactory threadFactory(final String name) {
         final AtomicLong count = new AtomicLong();
-        return new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable runnable) {
-                Thread thread = Executors.defaultThreadFactory().newThread(runnable);
-                thread.setName(name + "-" + Long.toString(count.getAndIncrement()));
-                //doesn't catch everything, just for extra safety
-                thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-                    @Override
-                    public void uncaughtException(Thread t, Throwable e) {
-                        logger.error("uncaught error", e);
-                    }
-                });
-                return thread;
-            }
+        return runnable -> {
+            Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+            thread.setName(name + "-" + count.getAndIncrement());
+            //doesn't catch everything, just for extra safety
+            thread.setUncaughtExceptionHandler((t, e) -> logger.error("uncaught error", e));
+            return thread;
         };
     }
 

--- a/src/test/java/com/sproutsocial/nsq/NsqdInstanceStateTest.java
+++ b/src/test/java/com/sproutsocial/nsq/NsqdInstanceStateTest.java
@@ -3,7 +3,6 @@ package com.sproutsocial.nsq;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -48,13 +47,6 @@ public class NsqdInstanceStateTest {
         return new NsqdInstance(Client.getDefaultClient(), "localhost:4150", stubPublisher(), 300);
     }
 
-    /** Injects a PubConnection into NsqdInstance.con via reflection (field is private). */
-    private static void injectCon(NsqdInstance instance, PubConnection con) throws Exception {
-        Field field = NsqdInstance.class.getDeclaredField("con");
-        field.setAccessible(true);
-        field.set(instance, con);
-    }
-
     @Test
     public void markFailureIfNotAlready_setsFailoverStartWhenNotConnected() {
         NsqdInstance instance = freshInstance();
@@ -80,12 +72,12 @@ public class NsqdInstanceStateTest {
     }
 
     @Test
-    public void clearConnection_closesSocketBeforeNullingReference() throws Exception {
+    public void clearConnection_closesSocketBeforeNullingReference() {
         Publisher publisher = stubPublisher();
         NsqdInstance instance = new NsqdInstance(
                 Client.getDefaultClient(), "localhost:4150", publisher, 300);
         TrackingPubConnection con = new TrackingPubConnection(Client.getDefaultClient(), publisher);
-        injectCon(instance, con);
+        instance.con = con;
 
         instance.clearConnection();
 

--- a/src/test/java/com/sproutsocial/nsq/NsqdInstanceStateTest.java
+++ b/src/test/java/com/sproutsocial/nsq/NsqdInstanceStateTest.java
@@ -1,0 +1,95 @@
+package com.sproutsocial.nsq;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for NsqdInstance state transitions, focusing on the clearAllConnections() fix.
+ *
+ * Regression for the 2026-05-08 incident: clearAllConnections() reset state to NOT_CONNECTED,
+ * discarding failoverStart and bypassing the backoff on every subsequent publish attempt.
+ */
+public class NsqdInstanceStateTest {
+
+    /** PubConnection that tracks close() calls without opening a real socket. */
+    static class TrackingPubConnection extends PubConnection {
+        boolean closeCalled = false;
+
+        TrackingPubConnection(Client client, Publisher publisher) {
+            super(client, HostAndPort.fromString("localhost:4150"), publisher);
+        }
+
+        @Override public synchronized void publish(String topic, byte[] data) throws IOException {}
+        @Override public synchronized void publish(String topic, List<byte[]> dataList) throws IOException {}
+
+        @Override
+        public void close() {
+            closeCalled = true;
+            // skip super — no real socket to close
+        }
+    }
+
+    private static Publisher stubPublisher() {
+        return new Publisher(Client.getDefaultClient(), (c, p) -> new BalanceStrategy() {
+            @Override public NsqdInstance getNsqdInstance() { throw new NSQException("not used"); }
+            @Override public void connectionClosed(PubConnection con) {}
+            @Override public int getFailoverDurationSecs() { return 300; }
+            @Override public void setFailoverDurationSecs(int s) {}
+        });
+    }
+
+    private static NsqdInstance freshInstance() {
+        return new NsqdInstance(Client.getDefaultClient(), "localhost:4150", stubPublisher(), 300);
+    }
+
+    /** Injects a PubConnection into NsqdInstance.con via reflection (field is private). */
+    private static void injectCon(NsqdInstance instance, PubConnection con) throws Exception {
+        Field field = NsqdInstance.class.getDeclaredField("con");
+        field.setAccessible(true);
+        field.set(instance, con);
+    }
+
+    @Test
+    public void markFailureIfNotAlready_setsFailoverStartWhenNotConnected() {
+        NsqdInstance instance = freshInstance();
+        long before = Util.clock();
+        instance.markFailureIfNotAlready();
+        assertTrue("failoverStart must be set after transitioning NOT_CONNECTED → FAILED",
+                instance.failoverStart >= before);
+    }
+
+    @Test
+    public void markFailureIfNotAlready_doesNotResetTimerWhenAlreadyFailed() {
+        NsqdInstance instance = freshInstance();
+        instance.markFailure();
+        long originalStart = instance.failoverStart;
+
+        Util.sleepQuietly(5);
+
+        instance.markFailureIfNotAlready();
+
+        assertEquals("failoverStart must NOT be reset when host is already FAILED — "
+                + "resetting would prevent recovery indefinitely",
+                originalStart, instance.failoverStart);
+    }
+
+    @Test
+    public void clearConnection_closesSocketBeforeNullingReference() throws Exception {
+        Publisher publisher = stubPublisher();
+        NsqdInstance instance = new NsqdInstance(
+                Client.getDefaultClient(), "localhost:4150", publisher, 300);
+        TrackingPubConnection con = new TrackingPubConnection(Client.getDefaultClient(), publisher);
+        injectCon(instance, con);
+
+        instance.clearConnection();
+
+        assertTrue("clearConnection() must close the socket to prevent TCP fd leak",
+                con.closeCalled);
+    }
+}

--- a/src/test/java/com/sproutsocial/nsq/PublisherInterruptTest.java
+++ b/src/test/java/com/sproutsocial/nsq/PublisherInterruptTest.java
@@ -1,0 +1,166 @@
+package com.sproutsocial.nsq;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Verifies that a thread interrupt does not cause Publisher to mark healthy hosts as failed.
+ *
+ * Regression for the 2026-05-08 incident: markFailure() was called unconditionally in the
+ * catch block, so a single interrupt cascaded across all connected hosts within milliseconds.
+ */
+public class PublisherInterruptTest {
+
+    @After
+    public void clearInterruptFlag() {
+        Thread.interrupted();
+    }
+
+    // ---- Test doubles ----
+
+    private static class SingleInstanceStrategy implements BalanceStrategy {
+        final NsqdInstance instance;
+
+        SingleInstanceStrategy(NsqdInstance instance) {
+            this.instance = instance;
+        }
+
+        @Override public NsqdInstance getNsqdInstance() { return instance; }
+        @Override public void connectionClosed(PubConnection c) {}
+        @Override public int getFailoverDurationSecs() { return 300; }
+        @Override public void setFailoverDurationSecs(int s) {}
+    }
+
+    /** NsqdInstance subclass that counts markFailure() calls and returns a fixed PubConnection. */
+    static class SpyNsqdInstance extends NsqdInstance {
+        int markFailureCount = 0;
+        private final PubConnection fakeCon;
+
+        SpyNsqdInstance(Client client, Publisher parent, PubConnection fakeCon) {
+            super(client, "localhost:4150", parent, 300);
+            this.fakeCon = fakeCon;
+        }
+
+        @Override
+        public synchronized void markFailure() {
+            markFailureCount++;
+        }
+
+        @Override
+        public PubConnection getCon() {
+            return fakeCon;
+        }
+    }
+
+    /** PubConnection subclass whose publish methods always throw NSQInterruptedException. */
+    static class InterruptingPubConnection extends PubConnection {
+        InterruptingPubConnection(Client client, Publisher publisher) {
+            super(client, HostAndPort.fromString("localhost:4150"), publisher);
+        }
+
+        @Override
+        public synchronized void publish(String topic, byte[] data) throws IOException {
+            throw new NSQInterruptedException("read interrupted");
+        }
+
+        @Override
+        public synchronized void publish(String topic, List<byte[]> dataList) throws IOException {
+            throw new NSQInterruptedException("read interrupted");
+        }
+    }
+
+    /** PubConnection subclass whose publish(byte[]) throws a plain NSQException (real failure). */
+    static class FailingPubConnection extends PubConnection {
+        FailingPubConnection(Client client, Publisher publisher) {
+            super(client, HostAndPort.fromString("localhost:4150"), publisher);
+        }
+
+        @Override
+        public synchronized void publish(String topic, byte[] data) throws IOException {
+            throw new NSQException("bad response:timeout");
+        }
+    }
+
+    /** PubConnection subclass whose publish methods are no-ops (success). */
+    static class SucceedingPubConnection extends PubConnection {
+        SucceedingPubConnection(Client client, Publisher publisher) {
+            super(client, HostAndPort.fromString("localhost:4151"), publisher);
+        }
+
+        @Override
+        public synchronized void publish(String topic, byte[] data) throws IOException {}
+
+        @Override
+        public synchronized void publish(String topic, List<byte[]> dataList) throws IOException {}
+    }
+
+    // ---- Tests ----
+
+    @Test
+    public void publish_byte_propagatesInterruptWithoutMarkingFailure() {
+        SpyNsqdInstance[] spyRef = new SpyNsqdInstance[1];
+        Publisher publisher = new Publisher(Client.getDefaultClient(), (client, pub) -> {
+            SpyNsqdInstance spy = new SpyNsqdInstance(client, pub, new InterruptingPubConnection(client, pub));
+            spyRef[0] = spy;
+            return new SingleInstanceStrategy(spy);
+        });
+
+        try {
+            publisher.publish("topic", new byte[]{0x01});
+            fail("NSQInterruptedException must propagate to caller");
+        } catch (NSQInterruptedException e) {
+            // expected
+        }
+
+        assertEquals("markFailure must NOT be called on thread interrupt", 0, spyRef[0].markFailureCount);
+    }
+
+    @Test
+    public void publish_list_propagatesInterruptWithoutMarkingFailure() {
+        SpyNsqdInstance[] spyRef = new SpyNsqdInstance[1];
+        Publisher publisher = new Publisher(Client.getDefaultClient(), (client, pub) -> {
+            SpyNsqdInstance spy = new SpyNsqdInstance(client, pub, new InterruptingPubConnection(client, pub));
+            spyRef[0] = spy;
+            return new SingleInstanceStrategy(spy);
+        });
+
+        try {
+            publisher.publish("topic", Arrays.asList(new byte[]{0x01}, new byte[]{0x02}));
+            fail("NSQInterruptedException must propagate to caller");
+        } catch (NSQInterruptedException e) {
+            // expected
+        }
+
+        assertEquals("markFailure must NOT be called on thread interrupt", 0, spyRef[0].markFailureCount);
+    }
+
+    @Test
+    public void normalException_stillCallsMarkFailure() {
+        // First call fails with a real error; retry to second instance succeeds.
+        SpyNsqdInstance[] spyRef = new SpyNsqdInstance[2];
+
+        Publisher publisher = new Publisher(Client.getDefaultClient(), (client, pub) -> {
+            spyRef[0] = new SpyNsqdInstance(client, pub, new FailingPubConnection(client, pub));
+            spyRef[1] = new SpyNsqdInstance(client, pub, new SucceedingPubConnection(client, pub));
+            int[] calls = {0};
+            return new BalanceStrategy() {
+                @Override public NsqdInstance getNsqdInstance() { return spyRef[calls[0]++ == 0 ? 0 : 1]; }
+                @Override public void connectionClosed(PubConnection c) {}
+                @Override public int getFailoverDurationSecs() { return 300; }
+                @Override public void setFailoverDurationSecs(int s) {}
+            };
+        });
+
+        publisher.publish("topic", new byte[]{0x01});
+
+        assertEquals("failing host must be marked failed", 1, spyRef[0].markFailureCount);
+        assertEquals("healthy retry host must NOT be marked failed", 0, spyRef[1].markFailureCount);
+    }
+}

--- a/src/test/java/com/sproutsocial/nsq/PublisherWithFailoverDockerTestIT.java
+++ b/src/test/java/com/sproutsocial/nsq/PublisherWithFailoverDockerTestIT.java
@@ -93,9 +93,10 @@ public class PublisherWithFailoverDockerTestIT extends BaseDockerTestIT {
 
         assertTrue(exceptionTriggered);
 
-        // As soon as the network flakiness subsides, we should be in a state
-        // where publishing succeeds again immediately.
         cluster.getNsqdNodes().forEach(cluster::reconnectNetworkFor);
+        // After a total-failure sweep all hosts are in FAILED state.  Wait for
+        // the failover backoff to expire (backupPublisher uses 5 s) before publishing.
+        Util.sleepQuietly(TimeUnit.SECONDS.toMillis(6));
 
         sendAndVerifyMessagesFromPrimary(publisher, handler);
     }


### PR DESCRIPTION
https://sprout.atlassian.net/browse/DATAINJ-5822

# Fix: Thread interrupts incorrectly marking healthy NSQ hosts as failed

## Background

During the 2026-05-08 NSQ publish failure incident, all 15 healthy NSQ hosts were marked as
failed within ~3ms. The root cause: `Publisher.publish()` caught thread-interrupt-caused
`NSQException`s the same way as genuine host failures, calling `markFailure()` unconditionally.
This triggered `clearAllConnections()` which reset all hosts to `NOT_CONNECTED`, bypassing the
45-second failover backoff on every subsequent publish attempt.

## Problem

Three distinct failure paths all led to the same incorrect outcome:

1. **Publisher catch blocks** — `Publisher.publish(String, byte[])` and `Publisher.publish(String, List)`
   called `markFailure()` in their `catch (Exception e)` blocks regardless of whether the failure
   was caused by an unreachable host or a thread interrupt.

2. **Connection read path** — `flushAndReadResponse()` in `Connection.java` correctly restored
   the interrupt flag and threw `NSQException("read interrupted")`, but the exception type was
   indistinguishable from any other `NSQException`, so callers had no way to differentiate it.

3. **Connect path** — `NsqdInstance.connectAttempt()` called `markFailure()` after any
   `IOException` from `Socket.connect()`. Since `PlainSocketImpl` is non-interruptible, an
   interrupted thread can receive an `IOException` here that is not a genuine connectivity failure.

4. **`clearAllConnections()` side effect** — when called after all hosts were exhausted, it
   called `clearConnection()` on each host, resetting state to `NOT_CONNECTED` and discarding
   `failoverStart`. This meant the failover backoff timer was wiped out on every sweep, so
   subsequent publish attempts immediately retried all hosts instead of waiting.

## Changes

### `NSQInterruptedException` (new class)
A dedicated `RuntimeException` subclass of `NSQException` used as a typed signal for
interrupt-caused failures. This lets callers distinguish interrupts from genuine host errors
without inspecting the interrupt flag at every catch site.

### `Connection.java`
`flushAndReadResponse()` now throws `NSQInterruptedException` instead of plain `NSQException`
when an `InterruptedException` is caught. The original `InterruptedException` is preserved as
the cause.

### `Publisher.java`
All four publish methods (`publish(String, byte[])`, `publish(String, List)`,
`publishDeferred` × 2) now catch `NSQInterruptedException` before the general
`catch (Exception e)` block and re-throw it immediately without calling `markFailure()`.
Genuine host failures continue to call `markFailure()` as before.

### `NsqdInstance.java`
- **`connectAttempt()`** — after catching `IOException`, checks
  `Thread.currentThread().isInterrupted()` and throws `NSQInterruptedException("connect interrupted")`
  instead of calling `markFailure()`. This handles the case where `Socket.connect()` completes
  but the thread was interrupted mid-connect.
- **`markFailureIfNotAlready()`** (new method) — transitions a host to `FAILED` only if it is
  not already in that state. When a host is already `FAILED`, the existing `failoverStart`
  timestamp is preserved so the backoff timer can expire naturally.
- **`clearConnection()`** — now calls `Util.closeQuietly(con)` before nulling the reference,
  fixing a TCP file descriptor leak that occurred whenever the connection reference was
  discarded without closing the underlying socket.

### `ListBasedBalanceStrategy.java`
`clearAllConnections()` now calls `markFailureIfNotAlready()` instead of `clearConnection()`.
This means hosts that are already in `FAILED` state retain their `failoverStart` timestamp —
the backoff timer is not reset, so recovery follows the configured `failoverDurationSecs`
window. An `ERROR` log is emitted when all hosts are exhausted so the event is visible in Sentry.

### `Util.java`
Replaced `Charset.forName("US-ASCII")` and `Charset.forName("UTF-8")` with
`StandardCharsets.US_ASCII` and `StandardCharsets.UTF_8` (available since Java 7, project
targets Java 8). Anonymous `ThreadFactory` / `UncaughtExceptionHandler` inner classes
modernised to lambdas.

## Tests

### `PublisherInterruptTest` (new)
Unit tests verifying that `NSQInterruptedException` propagates from `Publisher.publish()` without
calling `markFailure()`:
- `publish_byte_propagatesInterruptWithoutMarkingFailure`
- `publish_list_propagatesInterruptWithoutMarkingFailure`
- `normalException_stillCallsMarkFailure` — confirms genuine host failures still penalise the host

### `NsqdInstanceStateTest` (new)
Unit tests for `NsqdInstance` state transitions:
- `markFailureIfNotAlready_setsFailoverStartWhenNotConnected` — timer is set on first failure
- `markFailureIfNotAlready_doesNotResetTimerWhenAlreadyFailed` — timer is preserved on repeat calls
- `clearConnection_closesSocketBeforeNullingReference` — socket is closed before reference is dropped

### `PublisherWithFailoverDockerTestIT` (updated)
After network reconnect, the test now waits for the failover backoff to expire (6 s, backupPublisher
uses 5 s) before asserting that publishing succeeds. Previously the test assumed recovery was
immediate, which was only true because `clearConnection()` bypassed the backoff by resetting state
to `NOT_CONNECTED`.

## Expected outcome

Only genuinely unreachable hosts are penalised with `markFailure()`. Thread interrupt failures
propagate immediately as `NSQInterruptedException` without touching host state. When all hosts
are exhausted, the failover backoff timers for already-failed hosts are preserved so recovery
follows the configured window rather than being bypassed on every sweep.
